### PR TITLE
Fall back to backup universe files in live trading when the expected ones are unavailable

### DIFF
--- a/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactory.cs
@@ -18,9 +18,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Python.Runtime;
+using QuantConnect.Configuration;
 using QuantConnect.Data;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
+using QuantConnect.Logging;
 using QuantConnect.Util;
 
 namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
@@ -30,10 +32,15 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
     /// </summary>
     public class LiveCustomDataSubscriptionEnumeratorFactory : ISubscriptionEnumeratorFactory
     {
+        // when the expected universe file is not available yet, we fall back to the backup universe file ("*.backup"),
+        // if any, as a last resort, when the market is open or within this time span before the next market open
+        private static readonly TimeSpan UniverseFileBackupFallbackWindow =
+            TimeSpan.FromMinutes(Config.GetInt("universe-file-backup-fallback-minutes", 30));
+
         private readonly TimeSpan _minimumIntervalCheck;
         private readonly ITimeProvider _timeProvider;
         private readonly Func<DateTime, DateTime> _dateAdjustment;
-        private readonly Func<SubscriptionDataSource, DateTime, SubscriptionDataSource> _sourceAdjustment;
+        private readonly bool _fallBackToBackupUniverseFiles;
         private readonly IObjectStore _objectStore;
 
         /// <summary>
@@ -43,17 +50,17 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         /// <param name="objectStore">The object store to use</param>
         /// <param name="dateAdjustment">Func that allows adjusting the datetime to use</param>
         /// <param name="minimumIntervalCheck">Allows specifying the minimum interval between each enumerator refresh and data check, default is 30 minutes</param>
-        /// <param name="sourceAdjustment">Optional func that allows adjusting the data source to read from, given the source and the current utc time,
-        /// e.g. to fall back to an alternative source when the expected one is not available.
-        /// It is evaluated at the same cadence as the enumerator refreshes</param>
+        /// <param name="fallBackToBackupUniverseFiles">Whether to fall back to the backup universe file ("*.backup"), if any, as a last resort
+        /// when the expected universe file is not available and the market is open or close to opening.
+        /// Only meaningful for universe subscriptions backed by local files</param>
         public LiveCustomDataSubscriptionEnumeratorFactory(ITimeProvider timeProvider, IObjectStore objectStore,
             Func<DateTime, DateTime> dateAdjustment = null, TimeSpan? minimumIntervalCheck = null,
-            Func<SubscriptionDataSource, DateTime, SubscriptionDataSource> sourceAdjustment = null)
+            bool fallBackToBackupUniverseFiles = false)
         {
             _timeProvider = timeProvider;
             _dateAdjustment = dateAdjustment;
             _minimumIntervalCheck = minimumIntervalCheck ?? TimeSpan.FromMinutes(30);
-            _sourceAdjustment = sourceAdjustment;
+            _fallBackToBackupUniverseFiles = fallBackToBackupUniverseFiles;
             _objectStore = objectStore;
         }
 
@@ -72,6 +79,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             var frontier = Ref.Create(_dateAdjustment?.Invoke(request.StartTimeLocal) ?? request.StartTimeLocal);
             var lastSourceRefreshTime = DateTime.MinValue;
             var sourceFactory = config.GetBaseDataInstance();
+            var sourceAdjustment = _fallBackToBackupUniverseFiles ? GetUniverseFileBackupSourceAdjustment(request, dataProvider) : null;
 
             // this is refreshing the enumerator stack for each new source
             var refresher = new RefreshEnumerator<BaseData>(() =>
@@ -93,9 +101,9 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
                     return Enumerable.Empty<BaseData>().GetEnumerator();
                 }
 
-                if (_sourceAdjustment != null)
+                if (sourceAdjustment != null)
                 {
-                    source = _sourceAdjustment(source, utcNow);
+                    source = sourceAdjustment(source, utcNow);
                 }
 
                 // fetch the new source and enumerate the data source reader
@@ -211,6 +219,55 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             )
         {
             return SubscriptionDataSourceReader.ForSource(source, dataCacheProvider, config, date, true, baseDataInstance, dataProvider, _objectStore);
+        }
+
+        /// <summary>
+        /// Gets a source adjustment for universe files as a safety net for when the expected universe file
+        /// is not available yet: when the market is open or close to opening (within <see cref="UniverseFileBackupFallbackWindow"/>
+        /// of the next market open), it falls back to the backup universe file ("*.backup") if present, as a last resort.
+        /// It is evaluated at the same cadence as the enumerator refreshes
+        /// </summary>
+        private static Func<SubscriptionDataSource, DateTime, SubscriptionDataSource> GetUniverseFileBackupSourceAdjustment(
+            SubscriptionRequest request, IDataProvider dataProvider)
+        {
+            var exchangeHours = request.Security.Exchange.Hours;
+            return (source, utcNow) =>
+            {
+                if (source.TransportMedium != SubscriptionTransportMedium.LocalFile)
+                {
+                    return source;
+                }
+
+                var localTime = utcNow.ConvertFromUtc(exchangeHours.TimeZone);
+                // only fall back when the market is open or close to opening, when the expected universe file should already be available
+                if (!exchangeHours.IsOpen(localTime, extendedMarketHours: false)
+                    // if the market is closed, GetNextMarketOpen returns the next day open
+                    && exchangeHours.GetNextMarketOpen(localTime, extendedMarketHours: false) - localTime > UniverseFileBackupFallbackWindow)
+                {
+                    return source;
+                }
+
+                if (CanFetchDataSource(dataProvider, source))
+                {
+                    return source;
+                }
+
+                var backupSource = new SubscriptionDataSource(source.Source + ".backup", source.TransportMedium, source.Format);
+                if (CanFetchDataSource(dataProvider, backupSource))
+                {
+                    Log.Trace($"LiveCustomDataSubscriptionEnumeratorFactory.GetUniverseFileBackupSourceAdjustment(): universe file '{source.Source}' is not available, " +
+                        $"falling back to backup universe file '{backupSource.Source}'");
+                    return backupSource;
+                }
+
+                return source;
+            };
+        }
+
+        private static bool CanFetchDataSource(IDataProvider dataProvider, SubscriptionDataSource source)
+        {
+            using var stream = dataProvider.Fetch(source.Source);
+            return stream != null;
         }
 
         private bool SourceRequiresFastForward(SubscriptionDataSource source)

--- a/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactory.cs
@@ -33,7 +33,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         private readonly TimeSpan _minimumIntervalCheck;
         private readonly ITimeProvider _timeProvider;
         private readonly Func<DateTime, DateTime> _dateAdjustment;
-        private readonly Func<DateTime, bool> _canRefresh;
         private readonly IObjectStore _objectStore;
 
         /// <summary>
@@ -43,15 +42,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         /// <param name="objectStore">The object store to use</param>
         /// <param name="dateAdjustment">Func that allows adjusting the datetime to use</param>
         /// <param name="minimumIntervalCheck">Allows specifying the minimum interval between each enumerator refresh and data check, default is 30 minutes</param>
-        /// <param name="canRefresh">Optional predicate that determines, given the current utc time, whether the source can be refreshed and read.
-        /// It is evaluated at the same cadence as the refresh interval, so once it returns true the source will be read within one interval</param>
         public LiveCustomDataSubscriptionEnumeratorFactory(ITimeProvider timeProvider, IObjectStore objectStore,
-            Func<DateTime, DateTime> dateAdjustment = null, TimeSpan? minimumIntervalCheck = null, Func<DateTime, bool> canRefresh = null)
+            Func<DateTime, DateTime> dateAdjustment = null, TimeSpan? minimumIntervalCheck = null)
         {
             _timeProvider = timeProvider;
             _dateAdjustment = dateAdjustment;
             _minimumIntervalCheck = minimumIntervalCheck ?? TimeSpan.FromMinutes(30);
-            _canRefresh = canRefresh;
             _objectStore = objectStore;
         }
 
@@ -83,13 +79,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
                 }
 
                 lastSourceRefreshTime = utcNow;
-
-                // the refresh gate, if any, is rate limited like the source refreshes so it's not evaluated in a tight loop
-                if (_canRefresh != null && !_canRefresh(utcNow))
-                {
-                    return Enumerable.Empty<BaseData>().GetEnumerator();
-                }
-
                 var localDate = _dateAdjustment?.Invoke(utcNow.ConvertFromUtc(config.ExchangeTimeZone).Date) ?? utcNow.ConvertFromUtc(config.ExchangeTimeZone).Date;
                 var source = sourceFactory.GetSource(config, localDate, true);
                 if (source == null)

--- a/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactory.cs
@@ -33,6 +33,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         private readonly TimeSpan _minimumIntervalCheck;
         private readonly ITimeProvider _timeProvider;
         private readonly Func<DateTime, DateTime> _dateAdjustment;
+        private readonly Func<DateTime, bool> _canRefresh;
         private readonly IObjectStore _objectStore;
 
         /// <summary>
@@ -42,12 +43,15 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         /// <param name="objectStore">The object store to use</param>
         /// <param name="dateAdjustment">Func that allows adjusting the datetime to use</param>
         /// <param name="minimumIntervalCheck">Allows specifying the minimum interval between each enumerator refresh and data check, default is 30 minutes</param>
+        /// <param name="canRefresh">Optional predicate that determines, given the current utc time, whether the source can be refreshed and read.
+        /// It is evaluated at the same cadence as the refresh interval, so once it returns true the source will be read within one interval</param>
         public LiveCustomDataSubscriptionEnumeratorFactory(ITimeProvider timeProvider, IObjectStore objectStore,
-            Func<DateTime, DateTime> dateAdjustment = null, TimeSpan? minimumIntervalCheck = null)
+            Func<DateTime, DateTime> dateAdjustment = null, TimeSpan? minimumIntervalCheck = null, Func<DateTime, bool> canRefresh = null)
         {
             _timeProvider = timeProvider;
             _dateAdjustment = dateAdjustment;
             _minimumIntervalCheck = minimumIntervalCheck ?? TimeSpan.FromMinutes(30);
+            _canRefresh = canRefresh;
             _objectStore = objectStore;
         }
 
@@ -79,6 +83,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
                 }
 
                 lastSourceRefreshTime = utcNow;
+
+                // the refresh gate, if any, is rate limited like the source refreshes so it's not evaluated in a tight loop
+                if (_canRefresh != null && !_canRefresh(utcNow))
+                {
+                    return Enumerable.Empty<BaseData>().GetEnumerator();
+                }
+
                 var localDate = _dateAdjustment?.Invoke(utcNow.ConvertFromUtc(config.ExchangeTimeZone).Date) ?? utcNow.ConvertFromUtc(config.ExchangeTimeZone).Date;
                 var source = sourceFactory.GetSource(config, localDate, true);
                 if (source == null)

--- a/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactory.cs
@@ -33,6 +33,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         private readonly TimeSpan _minimumIntervalCheck;
         private readonly ITimeProvider _timeProvider;
         private readonly Func<DateTime, DateTime> _dateAdjustment;
+        private readonly Func<SubscriptionDataSource, DateTime, SubscriptionDataSource> _sourceAdjustment;
         private readonly IObjectStore _objectStore;
 
         /// <summary>
@@ -42,12 +43,17 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         /// <param name="objectStore">The object store to use</param>
         /// <param name="dateAdjustment">Func that allows adjusting the datetime to use</param>
         /// <param name="minimumIntervalCheck">Allows specifying the minimum interval between each enumerator refresh and data check, default is 30 minutes</param>
+        /// <param name="sourceAdjustment">Optional func that allows adjusting the data source to read from, given the source and the current utc time,
+        /// e.g. to fall back to an alternative source when the expected one is not available.
+        /// It is evaluated at the same cadence as the enumerator refreshes</param>
         public LiveCustomDataSubscriptionEnumeratorFactory(ITimeProvider timeProvider, IObjectStore objectStore,
-            Func<DateTime, DateTime> dateAdjustment = null, TimeSpan? minimumIntervalCheck = null)
+            Func<DateTime, DateTime> dateAdjustment = null, TimeSpan? minimumIntervalCheck = null,
+            Func<SubscriptionDataSource, DateTime, SubscriptionDataSource> sourceAdjustment = null)
         {
             _timeProvider = timeProvider;
             _dateAdjustment = dateAdjustment;
             _minimumIntervalCheck = minimumIntervalCheck ?? TimeSpan.FromMinutes(30);
+            _sourceAdjustment = sourceAdjustment;
             _objectStore = objectStore;
         }
 
@@ -85,6 +91,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
                 {
                     // a null source is equivalent to an unreachable source: no data this cycle, retry on the next refresh
                     return Enumerable.Empty<BaseData>().GetEnumerator();
+                }
+
+                if (_sourceAdjustment != null)
+                {
+                    source = _sourceAdjustment(source, utcNow);
                 }
 
                 // fetch the new source and enumerate the data source reader

--- a/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactory.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Python.Runtime;
 using QuantConnect.Configuration;
@@ -23,6 +24,7 @@ using QuantConnect.Data;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
 using QuantConnect.Logging;
+using QuantConnect.Securities;
 using QuantConnect.Util;
 
 namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
@@ -79,7 +81,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             var frontier = Ref.Create(_dateAdjustment?.Invoke(request.StartTimeLocal) ?? request.StartTimeLocal);
             var lastSourceRefreshTime = DateTime.MinValue;
             var sourceFactory = config.GetBaseDataInstance();
-            var sourceAdjustment = _fallBackToBackupUniverseFiles ? GetUniverseFileBackupSourceAdjustment(request, dataProvider) : null;
+            var exchangeHours = request.Security.Exchange.Hours;
 
             // this is refreshing the enumerator stack for each new source
             var refresher = new RefreshEnumerator<BaseData>(() =>
@@ -101,13 +103,17 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
                     return Enumerable.Empty<BaseData>().GetEnumerator();
                 }
 
-                if (sourceAdjustment != null)
+                var sourceDataProvider = dataProvider;
+                if (_fallBackToBackupUniverseFiles
+                    && source.TransportMedium == SubscriptionTransportMedium.LocalFile
+                    && IsUniverseFileBackupFallbackActive(exchangeHours, utcNow))
                 {
-                    source = sourceAdjustment(source, utcNow);
+                    // if the expected universe file is not available, the backup universe file, if any, will be read as a last resort
+                    sourceDataProvider = new BackupUniverseFileDataProvider(dataProvider);
                 }
 
                 // fetch the new source and enumerate the data source reader
-                var enumerator = EnumerateDataSourceReader(config, dataProvider, frontier, source, localDate, sourceFactory);
+                var enumerator = EnumerateDataSourceReader(config, sourceDataProvider, frontier, source, localDate, sourceFactory);
 
                 if (SourceRequiresFastForward(source))
                 {
@@ -222,52 +228,16 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         }
 
         /// <summary>
-        /// Gets a source adjustment for universe files as a safety net for when the expected universe file
-        /// is not available yet: when the market is open or close to opening (within <see cref="UniverseFileBackupFallbackWindow"/>
-        /// of the next market open), it falls back to the backup universe file ("*.backup") if present, as a last resort.
+        /// Determines whether the backup universe file fallback is active, which is only when the market is open or close to opening
+        /// (within <see cref="UniverseFileBackupFallbackWindow"/> of the next market open), when the expected universe file should already be available.
         /// It is evaluated at the same cadence as the enumerator refreshes
         /// </summary>
-        private static Func<SubscriptionDataSource, DateTime, SubscriptionDataSource> GetUniverseFileBackupSourceAdjustment(
-            SubscriptionRequest request, IDataProvider dataProvider)
+        private static bool IsUniverseFileBackupFallbackActive(SecurityExchangeHours exchangeHours, DateTime utcNow)
         {
-            var exchangeHours = request.Security.Exchange.Hours;
-            return (source, utcNow) =>
-            {
-                if (source.TransportMedium != SubscriptionTransportMedium.LocalFile)
-                {
-                    return source;
-                }
-
-                var localTime = utcNow.ConvertFromUtc(exchangeHours.TimeZone);
-                // only fall back when the market is open or close to opening, when the expected universe file should already be available
-                if (!exchangeHours.IsOpen(localTime, extendedMarketHours: false)
-                    // if the market is closed, GetNextMarketOpen returns the next day open
-                    && exchangeHours.GetNextMarketOpen(localTime, extendedMarketHours: false) - localTime > UniverseFileBackupFallbackWindow)
-                {
-                    return source;
-                }
-
-                if (CanFetchDataSource(dataProvider, source))
-                {
-                    return source;
-                }
-
-                var backupSource = new SubscriptionDataSource(source.Source + ".backup", source.TransportMedium, source.Format);
-                if (CanFetchDataSource(dataProvider, backupSource))
-                {
-                    Log.Trace($"LiveCustomDataSubscriptionEnumeratorFactory.GetUniverseFileBackupSourceAdjustment(): universe file '{source.Source}' is not available, " +
-                        $"falling back to backup universe file '{backupSource.Source}'");
-                    return backupSource;
-                }
-
-                return source;
-            };
-        }
-
-        private static bool CanFetchDataSource(IDataProvider dataProvider, SubscriptionDataSource source)
-        {
-            using var stream = dataProvider.Fetch(source.Source);
-            return stream != null;
+            var localTime = utcNow.ConvertFromUtc(exchangeHours.TimeZone);
+            return exchangeHours.IsOpen(localTime, extendedMarketHours: false)
+                // if the market is closed, GetNextMarketOpen returns the next day open
+                || exchangeHours.GetNextMarketOpen(localTime, extendedMarketHours: false) - localTime <= UniverseFileBackupFallbackWindow;
         }
 
         private bool SourceRequiresFastForward(SubscriptionDataSource source)
@@ -284,6 +254,45 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         private static TimeSpan GetMaximumDataAge(TimeSpan increment)
         {
             return TimeSpan.FromTicks(Math.Max(increment.Ticks, TimeSpan.FromSeconds(5).Ticks));
+        }
+
+        /// <summary>
+        /// Data provider wrapper that falls back to the backup universe file ("*.backup"), if any,
+        /// when the expected universe file can't be fetched, as a last resort
+        /// </summary>
+        private sealed class BackupUniverseFileDataProvider : IDataProvider
+        {
+            private readonly IDataProvider _dataProvider;
+
+            public event EventHandler<DataProviderNewDataRequestEventArgs> NewDataRequest
+            {
+                add => _dataProvider.NewDataRequest += value;
+                remove => _dataProvider.NewDataRequest -= value;
+            }
+
+            public BackupUniverseFileDataProvider(IDataProvider dataProvider)
+            {
+                _dataProvider = dataProvider;
+            }
+
+            public Stream Fetch(string key)
+            {
+                var stream = _dataProvider.Fetch(key);
+                if (stream != null)
+                {
+                    return stream;
+                }
+
+                var backupKey = key + ".backup";
+                stream = _dataProvider.Fetch(backupKey);
+                if (stream != null)
+                {
+                    Log.Trace($"LiveCustomDataSubscriptionEnumeratorFactory.BackupUniverseFileDataProvider.Fetch(): universe file '{key}' is not available, " +
+                        $"falling back to backup universe file '{backupKey}'");
+                }
+
+                return stream;
+            }
         }
     }
 }

--- a/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactory.cs
@@ -42,7 +42,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         private readonly TimeSpan _minimumIntervalCheck;
         private readonly ITimeProvider _timeProvider;
         private readonly Func<DateTime, DateTime> _dateAdjustment;
-        private readonly bool _fallBackToBackupUniverseFiles;
+        private readonly BackupUniverseFileDataProvider _backupUniverseFileDataProvider;
         private readonly IObjectStore _objectStore;
 
         /// <summary>
@@ -62,8 +62,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
             _timeProvider = timeProvider;
             _dateAdjustment = dateAdjustment;
             _minimumIntervalCheck = minimumIntervalCheck ?? TimeSpan.FromMinutes(30);
-            _fallBackToBackupUniverseFiles = fallBackToBackupUniverseFiles;
             _objectStore = objectStore;
+            if (fallBackToBackupUniverseFiles)
+            {
+                _backupUniverseFileDataProvider = new BackupUniverseFileDataProvider();
+            }
         }
 
         /// <summary>
@@ -95,7 +98,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
                 }
 
                 lastSourceRefreshTime = utcNow;
-                var localDate = _dateAdjustment?.Invoke(utcNow.ConvertFromUtc(config.ExchangeTimeZone).Date) ?? utcNow.ConvertFromUtc(config.ExchangeTimeZone).Date;
+                var localTime = utcNow.ConvertFromUtc(config.ExchangeTimeZone);
+                var localDate = _dateAdjustment?.Invoke(localTime.Date) ?? localTime.Date;
                 var source = sourceFactory.GetSource(config, localDate, true);
                 if (source == null)
                 {
@@ -104,12 +108,13 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
                 }
 
                 var sourceDataProvider = dataProvider;
-                if (_fallBackToBackupUniverseFiles
+                if (_backupUniverseFileDataProvider != null
                     && source.TransportMedium == SubscriptionTransportMedium.LocalFile
-                    && IsUniverseFileBackupFallbackActive(exchangeHours, utcNow))
+                    && IsUniverseFileBackupFallbackActive(exchangeHours, localTime))
                 {
                     // if the expected universe file is not available, the backup universe file, if any, will be read as a last resort
-                    sourceDataProvider = new BackupUniverseFileDataProvider(dataProvider);
+                    _backupUniverseFileDataProvider.SetDataProvider(dataProvider);
+                    sourceDataProvider = _backupUniverseFileDataProvider;
                 }
 
                 // fetch the new source and enumerate the data source reader
@@ -232,9 +237,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         /// (within <see cref="UniverseFileBackupFallbackWindow"/> of the next market open), when the expected universe file should already be available.
         /// It is evaluated at the same cadence as the enumerator refreshes
         /// </summary>
-        private static bool IsUniverseFileBackupFallbackActive(SecurityExchangeHours exchangeHours, DateTime utcNow)
+        /// <param name="exchangeHours">The exchange hours of the security</param>
+        /// <param name="localTime">The current time in the exchange time zone</param>
+        private static bool IsUniverseFileBackupFallbackActive(SecurityExchangeHours exchangeHours, DateTime localTime)
         {
-            var localTime = utcNow.ConvertFromUtc(exchangeHours.TimeZone);
             return exchangeHours.IsOpen(localTime, extendedMarketHours: false)
                 // if the market is closed, GetNextMarketOpen returns the next day open
                 || exchangeHours.GetNextMarketOpen(localTime, extendedMarketHours: false) - localTime <= UniverseFileBackupFallbackWindow;
@@ -262,15 +268,21 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
         /// </summary>
         private sealed class BackupUniverseFileDataProvider : IDataProvider
         {
-            private readonly IDataProvider _dataProvider;
+            private IDataProvider _dataProvider;
 
+            /// <summary>
+            /// Event raised each time data fetch is finished (successfully or not)
+            /// </summary>
             public event EventHandler<DataProviderNewDataRequestEventArgs> NewDataRequest
             {
-                add => _dataProvider.NewDataRequest += value;
-                remove => _dataProvider.NewDataRequest -= value;
+                add => _dataProvider?.NewDataRequest += value;
+                remove => _dataProvider?.NewDataRequest -= value;
             }
 
-            public BackupUniverseFileDataProvider(IDataProvider dataProvider)
+            /// <summary>
+            /// Sets the data provider to wrap, forwarding its <see cref="IDataProvider.NewDataRequest"/> events
+            /// </summary>
+            public void SetDataProvider(IDataProvider dataProvider)
             {
                 _dataProvider = dataProvider;
             }

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -42,7 +42,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
     {
         private static readonly int MaximumWarmupHistoryDaysLookBack = Config.GetInt("maximum-warmup-history-days-look-back", 5);
 
-        // when the expected chain universe file is not available yet, we fall back to the backup universe file ("*.backup"),
+        // when the expected universe file is not available yet, we fall back to the backup universe file ("*.backup"),
         // if any, as a last resort, when the market is open or within this time span before the next market open
         private static readonly TimeSpan UniverseFileBackupFallbackWindow =
             TimeSpan.FromMinutes(Config.GetInt("universe-file-backup-fallback-minutes", 30));
@@ -422,17 +422,12 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         }
 
         /// <summary>
-        /// Gets a source adjustment for chain universe files as a safety net for when the expected universe file
+        /// Gets a source adjustment for universe files as a safety net for when the expected universe file
         /// is not available yet: when the market is open or close to opening (within <see cref="UniverseFileBackupFallbackWindow"/>
         /// of the next market open), it falls back to the backup universe file ("*.backup") if present, as a last resort
         /// </summary>
         private Func<SubscriptionDataSource, DateTime, SubscriptionDataSource> GetUniverseFileBackupSourceAdjustment(SubscriptionRequest request)
         {
-            if (request.Universe is not (OptionChainUniverse or FuturesChainUniverse))
-            {
-                return null;
-            }
-
             var exchangeHours = request.Security.Exchange.Hours;
             return (source, utcNow) =>
             {

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -61,10 +61,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         private static ReferenceWrapper<DateTime> _lastUtcDateShiftUpdate;
         private static ReferenceWrapper<TimeSpan> _scheduledUniverseUtcTimeShift;
 
-        // option chain universe files can be big, so we delay reading them until the market is open or close to opening
-        // instead of reading them around the clock
-        private static readonly TimeSpan PreOpenUniverseFileRefreshWindow = TimeSpan.FromHours(1);
-
         /// <summary>
         /// Public flag indicator that the thread is still busy.
         /// </summary>
@@ -360,8 +356,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     _algorithm.ObjectStore,
                     // we adjust time to the previous tradable date
                     time => Time.GetStartTimeForTradeBars(request.Security.Exchange.Hours, time, Time.OneDay, 1, false, config.DataTimeZone, _algorithm.Settings.DailyPreciseEndTime),
-                    TimeSpan.FromMinutes(10),
-                    canRefresh: GetUniverseFileRefreshGate(request)
+                    TimeSpan.FromMinutes(10)
                 );
                 var enumeratorStack = factory.CreateEnumerator(request, _dataProvider);
 
@@ -418,28 +413,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     + TimeSpan.FromSeconds(DateTime.UtcNow.Second));
             }
             return _scheduledUniverseUtcTimeShift.Value;
-        }
-
-        /// <summary>
-        /// Gets a gate for reading a universe file, for universes whose files should not be read around the clock,
-        /// like option chains, which can be big: they are only read while the market is open
-        /// or within <see cref="PreOpenUniverseFileRefreshWindow"/> of the next market open
-        /// </summary>
-        private static Func<DateTime, bool> GetUniverseFileRefreshGate(SubscriptionRequest request)
-        {
-            if (request.Universe is not OptionChainUniverse)
-            {
-                return null;
-            }
-
-            var exchangeHours = request.Security.Exchange.Hours;
-            return utcNow =>
-            {
-                var localTime = utcNow.ConvertFromUtc(exchangeHours.TimeZone);
-                return exchangeHours.IsOpen(localTime, extendedMarketHours: false)
-                    // if the market is closed, GetNextMarketOpen returns the next day open
-                    || exchangeHours.GetNextMarketOpen(localTime, extendedMarketHours: false) - localTime <= PreOpenUniverseFileRefreshWindow;
-            };
         }
 
         /// <summary>

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -42,11 +42,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
     {
         private static readonly int MaximumWarmupHistoryDaysLookBack = Config.GetInt("maximum-warmup-history-days-look-back", 5);
 
-        // when the expected universe file is not available yet, we fall back to the backup universe file ("*.backup"),
-        // if any, as a last resort, when the market is open or within this time span before the next market open
-        private static readonly TimeSpan UniverseFileBackupFallbackWindow =
-            TimeSpan.FromMinutes(Config.GetInt("universe-file-backup-fallback-minutes", 30));
-
         private LiveNodePacket _job;
 
         // used to get current time
@@ -362,7 +357,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     // we adjust time to the previous tradable date
                     time => Time.GetStartTimeForTradeBars(request.Security.Exchange.Hours, time, Time.OneDay, 1, false, config.DataTimeZone, _algorithm.Settings.DailyPreciseEndTime),
                     TimeSpan.FromMinutes(10),
-                    sourceAdjustment: GetUniverseFileBackupSourceAdjustment(request)
+                    // when the expected universe file is not available yet, fall back to the backup universe file as a last resort
+                    fallBackToBackupUniverseFiles: true
                 );
                 var enumeratorStack = factory.CreateEnumerator(request, _dataProvider);
 
@@ -419,53 +415,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     + TimeSpan.FromSeconds(DateTime.UtcNow.Second));
             }
             return _scheduledUniverseUtcTimeShift.Value;
-        }
-
-        /// <summary>
-        /// Gets a source adjustment for universe files as a safety net for when the expected universe file
-        /// is not available yet: when the market is open or close to opening (within <see cref="UniverseFileBackupFallbackWindow"/>
-        /// of the next market open), it falls back to the backup universe file ("*.backup") if present, as a last resort
-        /// </summary>
-        private Func<SubscriptionDataSource, DateTime, SubscriptionDataSource> GetUniverseFileBackupSourceAdjustment(SubscriptionRequest request)
-        {
-            var exchangeHours = request.Security.Exchange.Hours;
-            return (source, utcNow) =>
-            {
-                if (source.TransportMedium != SubscriptionTransportMedium.LocalFile)
-                {
-                    return source;
-                }
-
-                var localTime = utcNow.ConvertFromUtc(exchangeHours.TimeZone);
-                // only fall back when the market is open or close to opening, when the expected universe file should already be available
-                if (!exchangeHours.IsOpen(localTime, extendedMarketHours: false)
-                    // if the market is closed, GetNextMarketOpen returns the next day open
-                    && exchangeHours.GetNextMarketOpen(localTime, extendedMarketHours: false) - localTime > UniverseFileBackupFallbackWindow)
-                {
-                    return source;
-                }
-
-                if (CanFetchDataSource(source))
-                {
-                    return source;
-                }
-
-                var backupSource = new SubscriptionDataSource(source.Source + ".backup", source.TransportMedium, source.Format);
-                if (CanFetchDataSource(backupSource))
-                {
-                    Log.Trace($"LiveTradingDataFeed.GetUniverseFileBackupSourceAdjustment(): universe file '{source.Source}' is not available, " +
-                        $"falling back to backup universe file '{backupSource.Source}'");
-                    return backupSource;
-                }
-
-                return source;
-            };
-        }
-
-        private bool CanFetchDataSource(SubscriptionDataSource source)
-        {
-            using var stream = _dataProvider.Fetch(source.Source);
-            return stream != null;
         }
 
         /// <summary>

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -61,6 +61,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
         private static ReferenceWrapper<DateTime> _lastUtcDateShiftUpdate;
         private static ReferenceWrapper<TimeSpan> _scheduledUniverseUtcTimeShift;
 
+        // option chain universe files can be big, so we delay reading them until the market is open or close to opening
+        // instead of reading them around the clock
+        private static readonly TimeSpan PreOpenUniverseFileRefreshWindow = TimeSpan.FromHours(1);
+
         /// <summary>
         /// Public flag indicator that the thread is still busy.
         /// </summary>
@@ -356,7 +360,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     _algorithm.ObjectStore,
                     // we adjust time to the previous tradable date
                     time => Time.GetStartTimeForTradeBars(request.Security.Exchange.Hours, time, Time.OneDay, 1, false, config.DataTimeZone, _algorithm.Settings.DailyPreciseEndTime),
-                    TimeSpan.FromMinutes(10)
+                    TimeSpan.FromMinutes(10),
+                    canRefresh: GetUniverseFileRefreshGate(request)
                 );
                 var enumeratorStack = factory.CreateEnumerator(request, _dataProvider);
 
@@ -413,6 +418,28 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     + TimeSpan.FromSeconds(DateTime.UtcNow.Second));
             }
             return _scheduledUniverseUtcTimeShift.Value;
+        }
+
+        /// <summary>
+        /// Gets a gate for reading a universe file, for universes whose files should not be read around the clock,
+        /// like option chains, which can be big: they are only read while the market is open
+        /// or within <see cref="PreOpenUniverseFileRefreshWindow"/> of the next market open
+        /// </summary>
+        private static Func<DateTime, bool> GetUniverseFileRefreshGate(SubscriptionRequest request)
+        {
+            if (request.Universe is not OptionChainUniverse)
+            {
+                return null;
+            }
+
+            var exchangeHours = request.Security.Exchange.Hours;
+            return utcNow =>
+            {
+                var localTime = utcNow.ConvertFromUtc(exchangeHours.TimeZone);
+                return exchangeHours.IsOpen(localTime, extendedMarketHours: false)
+                    // if the market is closed, GetNextMarketOpen returns the next day open
+                    || exchangeHours.GetNextMarketOpen(localTime, extendedMarketHours: false) - localTime <= PreOpenUniverseFileRefreshWindow;
+            };
         }
 
         /// <summary>

--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -42,6 +42,11 @@ namespace QuantConnect.Lean.Engine.DataFeeds
     {
         private static readonly int MaximumWarmupHistoryDaysLookBack = Config.GetInt("maximum-warmup-history-days-look-back", 5);
 
+        // when the expected chain universe file is not available yet, we fall back to the backup universe file ("*.backup"),
+        // if any, as a last resort, when the market is open or within this time span before the next market open
+        private static readonly TimeSpan UniverseFileBackupFallbackWindow =
+            TimeSpan.FromMinutes(Config.GetInt("universe-file-backup-fallback-minutes", 30));
+
         private LiveNodePacket _job;
 
         // used to get current time
@@ -356,7 +361,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     _algorithm.ObjectStore,
                     // we adjust time to the previous tradable date
                     time => Time.GetStartTimeForTradeBars(request.Security.Exchange.Hours, time, Time.OneDay, 1, false, config.DataTimeZone, _algorithm.Settings.DailyPreciseEndTime),
-                    TimeSpan.FromMinutes(10)
+                    TimeSpan.FromMinutes(10),
+                    sourceAdjustment: GetUniverseFileBackupSourceAdjustment(request)
                 );
                 var enumeratorStack = factory.CreateEnumerator(request, _dataProvider);
 
@@ -413,6 +419,58 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     + TimeSpan.FromSeconds(DateTime.UtcNow.Second));
             }
             return _scheduledUniverseUtcTimeShift.Value;
+        }
+
+        /// <summary>
+        /// Gets a source adjustment for chain universe files as a safety net for when the expected universe file
+        /// is not available yet: when the market is open or close to opening (within <see cref="UniverseFileBackupFallbackWindow"/>
+        /// of the next market open), it falls back to the backup universe file ("*.backup") if present, as a last resort
+        /// </summary>
+        private Func<SubscriptionDataSource, DateTime, SubscriptionDataSource> GetUniverseFileBackupSourceAdjustment(SubscriptionRequest request)
+        {
+            if (request.Universe is not (OptionChainUniverse or FuturesChainUniverse))
+            {
+                return null;
+            }
+
+            var exchangeHours = request.Security.Exchange.Hours;
+            return (source, utcNow) =>
+            {
+                if (source.TransportMedium != SubscriptionTransportMedium.LocalFile)
+                {
+                    return source;
+                }
+
+                var localTime = utcNow.ConvertFromUtc(exchangeHours.TimeZone);
+                // only fall back when the market is open or close to opening, when the expected universe file should already be available
+                if (!exchangeHours.IsOpen(localTime, extendedMarketHours: false)
+                    // if the market is closed, GetNextMarketOpen returns the next day open
+                    && exchangeHours.GetNextMarketOpen(localTime, extendedMarketHours: false) - localTime > UniverseFileBackupFallbackWindow)
+                {
+                    return source;
+                }
+
+                if (CanFetchDataSource(source))
+                {
+                    return source;
+                }
+
+                var backupSource = new SubscriptionDataSource(source.Source + ".backup", source.TransportMedium, source.Format);
+                if (CanFetchDataSource(backupSource))
+                {
+                    Log.Trace($"LiveTradingDataFeed.GetUniverseFileBackupSourceAdjustment(): universe file '{source.Source}' is not available, " +
+                        $"falling back to backup universe file '{backupSource.Source}'");
+                    return backupSource;
+                }
+
+                return source;
+            };
+        }
+
+        private bool CanFetchDataSource(SubscriptionDataSource source)
+        {
+            using var stream = _dataProvider.Fetch(source.Source);
+            return stream != null;
         }
 
         /// <summary>

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactoryTests.cs
@@ -549,6 +549,51 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
             enumerator.DisposeSafely();
         }
 
+        [Test]
+        public void RespectsRefreshGate()
+        {
+            var referenceLocal = new DateTime(2017, 10, 12);
+            var referenceUtc = referenceLocal.ConvertToUtc(TimeZones.NewYork);
+
+            var timeProvider = new ManualTimeProvider(referenceUtc);
+
+            var dataSourceReader = new Mock<ISubscriptionDataSourceReader>();
+            dataSourceReader.Setup(dsr => dsr.Read(It.IsAny<SubscriptionDataSource>()))
+                .Returns(() => new[] { new LocalFileData { EndTime = timeProvider.GetUtcNow().ConvertFromUtc(TimeZones.NewYork) } })
+                .Verifiable();
+
+            var config = new SubscriptionDataConfig(typeof(LocalFileData), Symbols.SPY, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, false);
+            var request = GetSubscriptionRequest(config, referenceUtc.AddDays(-1), referenceUtc.AddDays(1));
+
+            var interval = TimeSpan.FromMinutes(30);
+            var canRefresh = false;
+            var factory = new TestableLiveCustomDataSubscriptionEnumeratorFactory(timeProvider, dataSourceReader.Object, interval, utcTime => canRefresh);
+            using var enumerator = factory.CreateEnumerator(request, null);
+
+            // while the gate is closed the source is never read, regardless of how much time passes
+            Assert.IsTrue(enumerator.MoveNext());
+            Assert.IsNull(enumerator.Current);
+            for (var i = 0; i < 5; i++)
+            {
+                timeProvider.Advance(interval);
+                Assert.IsTrue(enumerator.MoveNext());
+                Assert.IsNull(enumerator.Current);
+            }
+            dataSourceReader.Verify(dsr => dsr.Read(It.IsAny<SubscriptionDataSource>()), Times.Never);
+
+            // the gate checks are rate limited like source refreshes, so within the same interval nothing is read either
+            canRefresh = true;
+            Assert.IsTrue(enumerator.MoveNext());
+            Assert.IsNull(enumerator.Current);
+            dataSourceReader.Verify(dsr => dsr.Read(It.IsAny<SubscriptionDataSource>()), Times.Never);
+
+            // once the gate is open, the next refresh reads the source
+            timeProvider.Advance(interval);
+            Assert.IsTrue(enumerator.MoveNext());
+            Assert.IsNotNull(enumerator.Current);
+            dataSourceReader.Verify(dsr => dsr.Read(It.IsAny<SubscriptionDataSource>()), Times.Once);
+        }
+
         private static void VerifyGetSourceInvocationCount(Mock<ISubscriptionDataSourceReader> dataSourceReader, int count, string source, SubscriptionTransportMedium medium, FileFormat fileFormat)
         {
             dataSourceReader.Verify(dsr => dsr.Read(It.Is<SubscriptionDataSource>(sds =>
@@ -630,8 +675,9 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
         {
             private readonly ISubscriptionDataSourceReader _dataSourceReader;
 
-            public TestableLiveCustomDataSubscriptionEnumeratorFactory(ITimeProvider timeProvider, ISubscriptionDataSourceReader dataSourceReader, TimeSpan? minimumIntervalCheck = null)
-                : base(timeProvider, null, minimumIntervalCheck: minimumIntervalCheck)
+            public TestableLiveCustomDataSubscriptionEnumeratorFactory(ITimeProvider timeProvider, ISubscriptionDataSourceReader dataSourceReader,
+                TimeSpan? minimumIntervalCheck = null, Func<DateTime, bool> canRefresh = null)
+                : base(timeProvider, null, minimumIntervalCheck: minimumIntervalCheck, canRefresh: canRefresh)
             {
                 _dataSourceReader = dataSourceReader;
             }

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactoryTests.cs
@@ -549,6 +549,51 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
             enumerator.DisposeSafely();
         }
 
+        [Test]
+        public void AllowsAdjustingTheDataSource()
+        {
+            var referenceLocal = new DateTime(2017, 10, 12);
+            var referenceUtc = new DateTime(2017, 10, 12).ConvertToUtc(TimeZones.NewYork);
+
+            var timeProvider = new ManualTimeProvider(referenceUtc);
+
+            var dataSourceReader = new Mock<ISubscriptionDataSourceReader>();
+            dataSourceReader.Setup(dsr => dsr.Read(It.IsAny<SubscriptionDataSource>()))
+                .Returns(() => new[] { new LocalFileData { EndTime = referenceLocal.AddSeconds(1) } })
+                .Verifiable();
+
+            var config = new SubscriptionDataConfig(typeof(LocalFileData), Symbols.SPY, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, false);
+            var request = GetSubscriptionRequest(config, referenceUtc.AddSeconds(-1), referenceUtc.AddDays(1));
+
+            var sourceAdjustmentTimesUtc = new List<DateTime>();
+            var factory = new TestableLiveCustomDataSubscriptionEnumeratorFactory(timeProvider, dataSourceReader.Object,
+                sourceAdjustment: (source, utcNow) =>
+                {
+                    sourceAdjustmentTimesUtc.Add(utcNow);
+                    return new SubscriptionDataSource(source.Source + ".backup", source.TransportMedium, source.Format);
+                });
+            using var enumerator = factory.CreateEnumerator(request, null);
+
+            Assert.IsTrue(enumerator.MoveNext());
+            Assert.IsNotNull(enumerator.Current);
+
+            // the adjusted source is the one that gets read, not the original one
+            VerifyGetSourceInvocationCount(dataSourceReader, 1, "local.file.source.backup", SubscriptionTransportMedium.LocalFile, FileFormat.Csv);
+            VerifyGetSourceInvocationCount(dataSourceReader, 0, "local.file.source", SubscriptionTransportMedium.LocalFile, FileFormat.Csv);
+
+            CollectionAssert.AreEqual(new[] { referenceUtc }, sourceAdjustmentTimesUtc);
+
+            // the source adjustment is rate limited like the source refreshes
+            Assert.IsTrue(enumerator.MoveNext());
+            Assert.IsNull(enumerator.Current);
+            Assert.AreEqual(1, sourceAdjustmentTimesUtc.Count);
+
+            timeProvider.Advance(TimeSpan.FromMinutes(30));
+            Assert.IsTrue(enumerator.MoveNext());
+            Assert.AreEqual(2, sourceAdjustmentTimesUtc.Count);
+            Assert.AreEqual(referenceUtc.AddMinutes(30), sourceAdjustmentTimesUtc[1]);
+        }
+
         private static void VerifyGetSourceInvocationCount(Mock<ISubscriptionDataSourceReader> dataSourceReader, int count, string source, SubscriptionTransportMedium medium, FileFormat fileFormat)
         {
             dataSourceReader.Verify(dsr => dsr.Read(It.Is<SubscriptionDataSource>(sds =>
@@ -630,8 +675,9 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
         {
             private readonly ISubscriptionDataSourceReader _dataSourceReader;
 
-            public TestableLiveCustomDataSubscriptionEnumeratorFactory(ITimeProvider timeProvider, ISubscriptionDataSourceReader dataSourceReader, TimeSpan? minimumIntervalCheck = null)
-                : base(timeProvider, null, minimumIntervalCheck: minimumIntervalCheck)
+            public TestableLiveCustomDataSubscriptionEnumeratorFactory(ITimeProvider timeProvider, ISubscriptionDataSourceReader dataSourceReader,
+                TimeSpan? minimumIntervalCheck = null, Func<SubscriptionDataSource, DateTime, SubscriptionDataSource> sourceAdjustment = null)
+                : base(timeProvider, null, minimumIntervalCheck: minimumIntervalCheck, sourceAdjustment: sourceAdjustment)
             {
                 _dataSourceReader = dataSourceReader;
             }

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactoryTests.cs
@@ -549,51 +549,6 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
             enumerator.DisposeSafely();
         }
 
-        [Test]
-        public void RespectsRefreshGate()
-        {
-            var referenceLocal = new DateTime(2017, 10, 12);
-            var referenceUtc = referenceLocal.ConvertToUtc(TimeZones.NewYork);
-
-            var timeProvider = new ManualTimeProvider(referenceUtc);
-
-            var dataSourceReader = new Mock<ISubscriptionDataSourceReader>();
-            dataSourceReader.Setup(dsr => dsr.Read(It.IsAny<SubscriptionDataSource>()))
-                .Returns(() => new[] { new LocalFileData { EndTime = timeProvider.GetUtcNow().ConvertFromUtc(TimeZones.NewYork) } })
-                .Verifiable();
-
-            var config = new SubscriptionDataConfig(typeof(LocalFileData), Symbols.SPY, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, false);
-            var request = GetSubscriptionRequest(config, referenceUtc.AddDays(-1), referenceUtc.AddDays(1));
-
-            var interval = TimeSpan.FromMinutes(30);
-            var canRefresh = false;
-            var factory = new TestableLiveCustomDataSubscriptionEnumeratorFactory(timeProvider, dataSourceReader.Object, interval, utcTime => canRefresh);
-            using var enumerator = factory.CreateEnumerator(request, null);
-
-            // while the gate is closed the source is never read, regardless of how much time passes
-            Assert.IsTrue(enumerator.MoveNext());
-            Assert.IsNull(enumerator.Current);
-            for (var i = 0; i < 5; i++)
-            {
-                timeProvider.Advance(interval);
-                Assert.IsTrue(enumerator.MoveNext());
-                Assert.IsNull(enumerator.Current);
-            }
-            dataSourceReader.Verify(dsr => dsr.Read(It.IsAny<SubscriptionDataSource>()), Times.Never);
-
-            // the gate checks are rate limited like source refreshes, so within the same interval nothing is read either
-            canRefresh = true;
-            Assert.IsTrue(enumerator.MoveNext());
-            Assert.IsNull(enumerator.Current);
-            dataSourceReader.Verify(dsr => dsr.Read(It.IsAny<SubscriptionDataSource>()), Times.Never);
-
-            // once the gate is open, the next refresh reads the source
-            timeProvider.Advance(interval);
-            Assert.IsTrue(enumerator.MoveNext());
-            Assert.IsNotNull(enumerator.Current);
-            dataSourceReader.Verify(dsr => dsr.Read(It.IsAny<SubscriptionDataSource>()), Times.Once);
-        }
-
         private static void VerifyGetSourceInvocationCount(Mock<ISubscriptionDataSourceReader> dataSourceReader, int count, string source, SubscriptionTransportMedium medium, FileFormat fileFormat)
         {
             dataSourceReader.Verify(dsr => dsr.Read(It.Is<SubscriptionDataSource>(sds =>
@@ -675,9 +630,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
         {
             private readonly ISubscriptionDataSourceReader _dataSourceReader;
 
-            public TestableLiveCustomDataSubscriptionEnumeratorFactory(ITimeProvider timeProvider, ISubscriptionDataSourceReader dataSourceReader,
-                TimeSpan? minimumIntervalCheck = null, Func<DateTime, bool> canRefresh = null)
-                : base(timeProvider, null, minimumIntervalCheck: minimumIntervalCheck, canRefresh: canRefresh)
+            public TestableLiveCustomDataSubscriptionEnumeratorFactory(ITimeProvider timeProvider, ISubscriptionDataSourceReader dataSourceReader, TimeSpan? minimumIntervalCheck = null)
+                : base(timeProvider, null, minimumIntervalCheck: minimumIntervalCheck)
             {
                 _dataSourceReader = dataSourceReader;
             }

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactoryTests.cs
@@ -559,72 +559,72 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
 
             var timeProvider = new ManualTimeProvider(referenceUtc);
 
-            var dataSourceReader = new Mock<ISubscriptionDataSourceReader>();
-            dataSourceReader.Setup(dsr => dsr.Read(It.IsAny<SubscriptionDataSource>()))
-                .Returns(() => new[] { new LocalFileData { EndTime = referenceLocal.AddSeconds(1) } })
-                .Verifiable();
-
             var expectedSourceAvailable = false;
             var dataProvider = new Mock<IDataProvider>();
             dataProvider.Setup(dp => dp.Fetch("local.file.source")).Returns(() => expectedSourceAvailable ? new MemoryStream() : null);
             dataProvider.Setup(dp => dp.Fetch("local.file.source.backup")).Returns(() => new MemoryStream());
 
+            var dataSourceReader = new Mock<ISubscriptionDataSourceReader>();
+            var factory = new TestableLiveCustomDataSubscriptionEnumeratorFactory(timeProvider, dataSourceReader.Object,
+                fallBackToBackupUniverseFiles: true);
+            SetUpDataSourceReader(dataSourceReader, factory, () => new LocalFileData { EndTime = timeProvider.GetUtcNow().ConvertFromUtc(TimeZones.NewYork).AddSeconds(1) });
+
             var config = new SubscriptionDataConfig(typeof(LocalFileData), Symbols.SPY, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, false);
             var request = GetSubscriptionRequest(config, referenceUtc.AddSeconds(-1), referenceUtc.AddDays(1));
 
-            var factory = new TestableLiveCustomDataSubscriptionEnumeratorFactory(timeProvider, dataSourceReader.Object,
-                fallBackToBackupUniverseFiles: true);
             using var enumerator = factory.CreateEnumerator(request, dataProvider.Object);
 
+            // the expected source is not available, so the backup file is the one that gets read, in a single read of the source
             Assert.IsTrue(enumerator.MoveNext());
             Assert.IsNotNull(enumerator.Current);
+            VerifyGetSourceInvocationCount(dataSourceReader, 1, "local.file.source", SubscriptionTransportMedium.LocalFile, FileFormat.Csv);
+            dataProvider.Verify(dp => dp.Fetch("local.file.source"), Times.Once);
+            dataProvider.Verify(dp => dp.Fetch("local.file.source.backup"), Times.Once);
 
-            // the expected source is not available, so the backup source is the one that gets read
-            VerifyGetSourceInvocationCount(dataSourceReader, 1, "local.file.source.backup", SubscriptionTransportMedium.LocalFile, FileFormat.Csv);
-            VerifyGetSourceInvocationCount(dataSourceReader, 0, "local.file.source", SubscriptionTransportMedium.LocalFile, FileFormat.Csv);
-            dataProvider.Verify(dp => dp.Fetch(It.IsAny<string>()), Times.Exactly(2));
-
-            // the fallback checks are rate limited like the source refreshes
+            // the fallback is rate limited like the source refreshes
             Assert.IsTrue(enumerator.MoveNext());
             Assert.IsNull(enumerator.Current);
             dataProvider.Verify(dp => dp.Fetch(It.IsAny<string>()), Times.Exactly(2));
 
-            // the expected source is re-checked and preferred on the next refresh once it becomes available
+            // the expected source is preferred on the next refresh once it becomes available, without touching the backup file
             expectedSourceAvailable = true;
             timeProvider.Advance(TimeSpan.FromMinutes(30));
             Assert.IsTrue(enumerator.MoveNext());
-            VerifyGetSourceInvocationCount(dataSourceReader, 1, "local.file.source", SubscriptionTransportMedium.LocalFile, FileFormat.Csv);
-            VerifyGetSourceInvocationCount(dataSourceReader, 1, "local.file.source.backup", SubscriptionTransportMedium.LocalFile, FileFormat.Csv);
+            Assert.IsNotNull(enumerator.Current);
+            VerifyGetSourceInvocationCount(dataSourceReader, 2, "local.file.source", SubscriptionTransportMedium.LocalFile, FileFormat.Csv);
+            dataProvider.Verify(dp => dp.Fetch("local.file.source"), Times.Exactly(2));
+            dataProvider.Verify(dp => dp.Fetch("local.file.source.backup"), Times.Once);
         }
 
         [Test]
         public void DoesNotFallBackToBackupUniverseFileFarFromMarketOpen()
         {
-            // midnight, more than the fallback window away from the next market open, so no backup probing happens
+            // midnight, more than the fallback window away from the next market open, so the backup file is never tried
             var referenceLocal = new DateTime(2017, 10, 12);
             var referenceUtc = referenceLocal.ConvertToUtc(TimeZones.NewYork);
 
             var timeProvider = new ManualTimeProvider(referenceUtc);
 
-            var dataSourceReader = new Mock<ISubscriptionDataSourceReader>();
-            dataSourceReader.Setup(dsr => dsr.Read(It.IsAny<SubscriptionDataSource>()))
-                .Returns(() => new[] { new LocalFileData { EndTime = referenceLocal.AddSeconds(1) } })
-                .Verifiable();
-
+            // the expected source is not available
             var dataProvider = new Mock<IDataProvider>();
+
+            var dataSourceReader = new Mock<ISubscriptionDataSourceReader>();
+            var factory = new TestableLiveCustomDataSubscriptionEnumeratorFactory(timeProvider, dataSourceReader.Object,
+                fallBackToBackupUniverseFiles: true);
+            SetUpDataSourceReader(dataSourceReader, factory, () => new LocalFileData { EndTime = timeProvider.GetUtcNow().ConvertFromUtc(TimeZones.NewYork).AddSeconds(1) });
 
             var config = new SubscriptionDataConfig(typeof(LocalFileData), Symbols.SPY, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, false);
             var request = GetSubscriptionRequest(config, referenceUtc.AddSeconds(-1), referenceUtc.AddDays(1));
 
-            var factory = new TestableLiveCustomDataSubscriptionEnumeratorFactory(timeProvider, dataSourceReader.Object,
-                fallBackToBackupUniverseFiles: true);
             using var enumerator = factory.CreateEnumerator(request, dataProvider.Object);
 
             Assert.IsTrue(enumerator.MoveNext());
+            Assert.IsNull(enumerator.Current);
 
-            // the expected source is read without any availability probing
+            // only the expected source is tried
             VerifyGetSourceInvocationCount(dataSourceReader, 1, "local.file.source", SubscriptionTransportMedium.LocalFile, FileFormat.Csv);
-            dataProvider.Verify(dp => dp.Fetch(It.IsAny<string>()), Times.Never);
+            dataProvider.Verify(dp => dp.Fetch("local.file.source"), Times.Once);
+            dataProvider.Verify(dp => dp.Fetch("local.file.source.backup"), Times.Never);
         }
 
         [Test]
@@ -636,24 +636,41 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
 
             var timeProvider = new ManualTimeProvider(referenceUtc);
 
-            var dataSourceReader = new Mock<ISubscriptionDataSourceReader>();
-            dataSourceReader.Setup(dsr => dsr.Read(It.IsAny<SubscriptionDataSource>()))
-                .Returns(() => new[] { new LocalFileData { EndTime = referenceLocal.AddSeconds(1) } })
-                .Verifiable();
-
+            // the expected source is not available
             var dataProvider = new Mock<IDataProvider>();
+
+            var dataSourceReader = new Mock<ISubscriptionDataSourceReader>();
+            var factory = new TestableLiveCustomDataSubscriptionEnumeratorFactory(timeProvider, dataSourceReader.Object);
+            SetUpDataSourceReader(dataSourceReader, factory, () => new LocalFileData { EndTime = timeProvider.GetUtcNow().ConvertFromUtc(TimeZones.NewYork).AddSeconds(1) });
 
             var config = new SubscriptionDataConfig(typeof(LocalFileData), Symbols.SPY, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, false);
             var request = GetSubscriptionRequest(config, referenceUtc.AddSeconds(-1), referenceUtc.AddDays(1));
 
-            var factory = new TestableLiveCustomDataSubscriptionEnumeratorFactory(timeProvider, dataSourceReader.Object);
             using var enumerator = factory.CreateEnumerator(request, dataProvider.Object);
 
             Assert.IsTrue(enumerator.MoveNext());
+            Assert.IsNull(enumerator.Current);
 
-            // the expected source is read without any availability probing
+            // only the expected source is tried
             VerifyGetSourceInvocationCount(dataSourceReader, 1, "local.file.source", SubscriptionTransportMedium.LocalFile, FileFormat.Csv);
-            dataProvider.Verify(dp => dp.Fetch(It.IsAny<string>()), Times.Never);
+            dataProvider.Verify(dp => dp.Fetch("local.file.source"), Times.Once);
+            dataProvider.Verify(dp => dp.Fetch("local.file.source.backup"), Times.Never);
+        }
+
+        /// <summary>
+        /// Sets up the mocked data source reader to fetch the source through the data cache provider the factory gave it,
+        /// like the real readers do, yielding a data point only when the source could be fetched
+        /// </summary>
+        private static void SetUpDataSourceReader(Mock<ISubscriptionDataSourceReader> dataSourceReader,
+            TestableLiveCustomDataSubscriptionEnumeratorFactory factory, Func<BaseData> dataFactory)
+        {
+            dataSourceReader.Setup(dsr => dsr.Read(It.IsAny<SubscriptionDataSource>()))
+                .Returns((SubscriptionDataSource source) =>
+                {
+                    using var stream = factory.DataCacheProvider.Fetch(source.Source);
+                    return stream == null ? Enumerable.Empty<BaseData>() : new[] { dataFactory() };
+                })
+                .Verifiable();
         }
 
         private static void VerifyGetSourceInvocationCount(Mock<ISubscriptionDataSourceReader> dataSourceReader, int count, string source, SubscriptionTransportMedium medium, FileFormat fileFormat)
@@ -737,6 +754,11 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
         {
             private readonly ISubscriptionDataSourceReader _dataSourceReader;
 
+            /// <summary>
+            /// The data cache provider the last data source reader was created with
+            /// </summary>
+            public IDataCacheProvider DataCacheProvider { get; private set; }
+
             public TestableLiveCustomDataSubscriptionEnumeratorFactory(ITimeProvider timeProvider, ISubscriptionDataSourceReader dataSourceReader,
                 TimeSpan? minimumIntervalCheck = null, bool fallBackToBackupUniverseFiles = false)
                 : base(timeProvider, null, minimumIntervalCheck: minimumIntervalCheck, fallBackToBackupUniverseFiles: fallBackToBackupUniverseFiles)
@@ -751,6 +773,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                 BaseData baseData,
                 IDataProvider dataProvider)
             {
+                DataCacheProvider = dataCacheProvider;
                 return _dataSourceReader;
             }
         }

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactoryTests.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Moq;
 using NUnit.Framework;
@@ -550,10 +551,11 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
         }
 
         [Test]
-        public void AllowsAdjustingTheDataSource()
+        public void FallsBackToBackupUniverseFileWhenExpectedSourceIsNotAvailable()
         {
-            var referenceLocal = new DateTime(2017, 10, 12);
-            var referenceUtc = new DateTime(2017, 10, 12).ConvertToUtc(TimeZones.NewYork);
+            // 10 am, the market is open, so the backup fallback is active
+            var referenceLocal = new DateTime(2017, 10, 12, 10, 0, 0);
+            var referenceUtc = referenceLocal.ConvertToUtc(TimeZones.NewYork);
 
             var timeProvider = new ManualTimeProvider(referenceUtc);
 
@@ -562,36 +564,96 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
                 .Returns(() => new[] { new LocalFileData { EndTime = referenceLocal.AddSeconds(1) } })
                 .Verifiable();
 
+            var expectedSourceAvailable = false;
+            var dataProvider = new Mock<IDataProvider>();
+            dataProvider.Setup(dp => dp.Fetch("local.file.source")).Returns(() => expectedSourceAvailable ? new MemoryStream() : null);
+            dataProvider.Setup(dp => dp.Fetch("local.file.source.backup")).Returns(() => new MemoryStream());
+
             var config = new SubscriptionDataConfig(typeof(LocalFileData), Symbols.SPY, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, false);
             var request = GetSubscriptionRequest(config, referenceUtc.AddSeconds(-1), referenceUtc.AddDays(1));
 
-            var sourceAdjustmentTimesUtc = new List<DateTime>();
             var factory = new TestableLiveCustomDataSubscriptionEnumeratorFactory(timeProvider, dataSourceReader.Object,
-                sourceAdjustment: (source, utcNow) =>
-                {
-                    sourceAdjustmentTimesUtc.Add(utcNow);
-                    return new SubscriptionDataSource(source.Source + ".backup", source.TransportMedium, source.Format);
-                });
-            using var enumerator = factory.CreateEnumerator(request, null);
+                fallBackToBackupUniverseFiles: true);
+            using var enumerator = factory.CreateEnumerator(request, dataProvider.Object);
 
             Assert.IsTrue(enumerator.MoveNext());
             Assert.IsNotNull(enumerator.Current);
 
-            // the adjusted source is the one that gets read, not the original one
+            // the expected source is not available, so the backup source is the one that gets read
             VerifyGetSourceInvocationCount(dataSourceReader, 1, "local.file.source.backup", SubscriptionTransportMedium.LocalFile, FileFormat.Csv);
             VerifyGetSourceInvocationCount(dataSourceReader, 0, "local.file.source", SubscriptionTransportMedium.LocalFile, FileFormat.Csv);
+            dataProvider.Verify(dp => dp.Fetch(It.IsAny<string>()), Times.Exactly(2));
 
-            CollectionAssert.AreEqual(new[] { referenceUtc }, sourceAdjustmentTimesUtc);
-
-            // the source adjustment is rate limited like the source refreshes
+            // the fallback checks are rate limited like the source refreshes
             Assert.IsTrue(enumerator.MoveNext());
             Assert.IsNull(enumerator.Current);
-            Assert.AreEqual(1, sourceAdjustmentTimesUtc.Count);
+            dataProvider.Verify(dp => dp.Fetch(It.IsAny<string>()), Times.Exactly(2));
 
+            // the expected source is re-checked and preferred on the next refresh once it becomes available
+            expectedSourceAvailable = true;
             timeProvider.Advance(TimeSpan.FromMinutes(30));
             Assert.IsTrue(enumerator.MoveNext());
-            Assert.AreEqual(2, sourceAdjustmentTimesUtc.Count);
-            Assert.AreEqual(referenceUtc.AddMinutes(30), sourceAdjustmentTimesUtc[1]);
+            VerifyGetSourceInvocationCount(dataSourceReader, 1, "local.file.source", SubscriptionTransportMedium.LocalFile, FileFormat.Csv);
+            VerifyGetSourceInvocationCount(dataSourceReader, 1, "local.file.source.backup", SubscriptionTransportMedium.LocalFile, FileFormat.Csv);
+        }
+
+        [Test]
+        public void DoesNotFallBackToBackupUniverseFileFarFromMarketOpen()
+        {
+            // midnight, more than the fallback window away from the next market open, so no backup probing happens
+            var referenceLocal = new DateTime(2017, 10, 12);
+            var referenceUtc = referenceLocal.ConvertToUtc(TimeZones.NewYork);
+
+            var timeProvider = new ManualTimeProvider(referenceUtc);
+
+            var dataSourceReader = new Mock<ISubscriptionDataSourceReader>();
+            dataSourceReader.Setup(dsr => dsr.Read(It.IsAny<SubscriptionDataSource>()))
+                .Returns(() => new[] { new LocalFileData { EndTime = referenceLocal.AddSeconds(1) } })
+                .Verifiable();
+
+            var dataProvider = new Mock<IDataProvider>();
+
+            var config = new SubscriptionDataConfig(typeof(LocalFileData), Symbols.SPY, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, false);
+            var request = GetSubscriptionRequest(config, referenceUtc.AddSeconds(-1), referenceUtc.AddDays(1));
+
+            var factory = new TestableLiveCustomDataSubscriptionEnumeratorFactory(timeProvider, dataSourceReader.Object,
+                fallBackToBackupUniverseFiles: true);
+            using var enumerator = factory.CreateEnumerator(request, dataProvider.Object);
+
+            Assert.IsTrue(enumerator.MoveNext());
+
+            // the expected source is read without any availability probing
+            VerifyGetSourceInvocationCount(dataSourceReader, 1, "local.file.source", SubscriptionTransportMedium.LocalFile, FileFormat.Csv);
+            dataProvider.Verify(dp => dp.Fetch(It.IsAny<string>()), Times.Never);
+        }
+
+        [Test]
+        public void DoesNotFallBackToBackupUniverseFileWhenNotConfigured()
+        {
+            // 10 am, the market is open, but the factory is not configured to fall back to backup universe files
+            var referenceLocal = new DateTime(2017, 10, 12, 10, 0, 0);
+            var referenceUtc = referenceLocal.ConvertToUtc(TimeZones.NewYork);
+
+            var timeProvider = new ManualTimeProvider(referenceUtc);
+
+            var dataSourceReader = new Mock<ISubscriptionDataSourceReader>();
+            dataSourceReader.Setup(dsr => dsr.Read(It.IsAny<SubscriptionDataSource>()))
+                .Returns(() => new[] { new LocalFileData { EndTime = referenceLocal.AddSeconds(1) } })
+                .Verifiable();
+
+            var dataProvider = new Mock<IDataProvider>();
+
+            var config = new SubscriptionDataConfig(typeof(LocalFileData), Symbols.SPY, Resolution.Daily, TimeZones.NewYork, TimeZones.NewYork, false, false, false);
+            var request = GetSubscriptionRequest(config, referenceUtc.AddSeconds(-1), referenceUtc.AddDays(1));
+
+            var factory = new TestableLiveCustomDataSubscriptionEnumeratorFactory(timeProvider, dataSourceReader.Object);
+            using var enumerator = factory.CreateEnumerator(request, dataProvider.Object);
+
+            Assert.IsTrue(enumerator.MoveNext());
+
+            // the expected source is read without any availability probing
+            VerifyGetSourceInvocationCount(dataSourceReader, 1, "local.file.source", SubscriptionTransportMedium.LocalFile, FileFormat.Csv);
+            dataProvider.Verify(dp => dp.Fetch(It.IsAny<string>()), Times.Never);
         }
 
         private static void VerifyGetSourceInvocationCount(Mock<ISubscriptionDataSourceReader> dataSourceReader, int count, string source, SubscriptionTransportMedium medium, FileFormat fileFormat)
@@ -676,8 +738,8 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
             private readonly ISubscriptionDataSourceReader _dataSourceReader;
 
             public TestableLiveCustomDataSubscriptionEnumeratorFactory(ITimeProvider timeProvider, ISubscriptionDataSourceReader dataSourceReader,
-                TimeSpan? minimumIntervalCheck = null, Func<SubscriptionDataSource, DateTime, SubscriptionDataSource> sourceAdjustment = null)
-                : base(timeProvider, null, minimumIntervalCheck: minimumIntervalCheck, sourceAdjustment: sourceAdjustment)
+                TimeSpan? minimumIntervalCheck = null, bool fallBackToBackupUniverseFiles = false)
+                : base(timeProvider, null, minimumIntervalCheck: minimumIntervalCheck, fallBackToBackupUniverseFiles: fallBackToBackupUniverseFiles)
             {
                 _dataSourceReader = dataSourceReader;
             }

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
@@ -280,6 +281,104 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             var expectedSelections = securityType == SecurityType.Future ? 2 : 1;
             Assert.AreEqual(expectedSelections, selectionHappened);
+        }
+
+        [TestCase(SecurityType.Option, false)]
+        [TestCase(SecurityType.Option, true)]
+        [TestCase(SecurityType.IndexOption, false)]
+        [TestCase(SecurityType.IndexOption, true)]
+        public void ChainSelectionFallsBackToBackupUniverseFileCloseToMarketOpen(SecurityType securityType, bool universeFileAvailable)
+        {
+            // start close to the market open (9:15 NY), within the backup universe file fallback window (30 minutes before the open by default)
+            _startDate = securityType == SecurityType.Option
+                ? new DateTime(2014, 6, 9, 13, 15, 0)
+                : new DateTime(2021, 1, 4, 14, 15, 0);
+            _manualTimeProvider.SetCurrentTimeUtc(_startDate);
+            var endDate = _startDate.AddDays(1);
+
+            _algorithm.SetBenchmark(x => 1);
+
+            var dataProvider = new BackupUniverseFileDataProvider(hideUniverseFiles: !universeFileAvailable);
+            var feed = RunDataFeed(runPostInitialize: false, dataProvider: dataProvider);
+
+            var selectionHappened = 0;
+            List<OptionUniverse> selectedContracts = null;
+            var option = securityType == SecurityType.Option
+                ? _algorithm.AddOption("AAPL")
+                : _algorithm.AddIndexOption("SPX");
+            option.SetFilter(universe =>
+            {
+                selectionHappened++;
+                selectedContracts = universe.ToList();
+
+                return universe;
+            });
+
+            _algorithm.PostInitialize();
+
+            // allow time for the exchange to pick up the selection point
+            Thread.Sleep(50);
+
+            ConsumeBridge(feed, TimeSpan.FromSeconds(30), true, ts =>
+            {
+                if (selectionHappened > 0)
+                {
+                    // we got what we wanted shortcut unit test
+                    _manualTimeProvider.SetCurrentTimeUtc(Time.EndOfTime);
+                }
+            },
+            endDate: endDate,
+            secondsTimeStep: 60);
+
+            Assert.AreEqual(1, selectionHappened);
+            Assert.IsNotNull(selectedContracts);
+            Assert.IsNotEmpty(selectedContracts);
+
+            if (universeFileAvailable)
+            {
+                // the universe file was available, so the backup file should not have even been checked
+                Assert.AreEqual(0, dataProvider.BackupUniverseFileRequests);
+            }
+            else
+            {
+                Assert.AreNotEqual(0, dataProvider.UniverseFileRequests);
+                Assert.AreNotEqual(0, dataProvider.BackupUniverseFileRequests);
+            }
+        }
+
+        [Test]
+        public void ChainSelectionDoesNotFallBackToBackupUniverseFileFarFromMarketOpen()
+        {
+            // start during the night: far from the market open, the missing universe file should not fall back to the backup file
+            _startDate = new DateTime(2014, 6, 9, 6, 0, 0);
+            _manualTimeProvider.SetCurrentTimeUtc(_startDate);
+            // stop before entering the fallback window, 30 minutes (by default) before the 9:30 NY market open
+            var endDate = new DateTime(2014, 6, 9, 12, 0, 0);
+
+            _algorithm.SetBenchmark(x => 1);
+
+            var dataProvider = new BackupUniverseFileDataProvider(hideUniverseFiles: true);
+            var feed = RunDataFeed(runPostInitialize: false, dataProvider: dataProvider);
+
+            var selectionHappened = 0;
+            var option = _algorithm.AddOption("AAPL");
+            option.SetFilter(universe =>
+            {
+                selectionHappened++;
+                return universe;
+            });
+
+            _algorithm.PostInitialize();
+
+            // allow time for the exchange to pick up the selection point
+            Thread.Sleep(50);
+
+            ConsumeBridge(feed, TimeSpan.FromSeconds(30), true, ts => { }, endDate: endDate, secondsTimeStep: 60);
+
+            // the universe file was tried but never available, and the backup file should not have been used
+            Assert.AreEqual(0, selectionHappened);
+            Assert.AreNotEqual(0, dataProvider.UniverseFileRequests);
+            Assert.AreEqual(0, dataProvider.BackupUniverseFileRequests);
         }
 
         [Test]
@@ -2914,7 +3013,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             Func<FuncDataQueueHandler, IEnumerable<BaseData>> getNextTicksFunction = null,
             Func<Symbol, bool, string, IEnumerable<Symbol>> lookupSymbolsFunction = null,
             Func<bool> canPerformSelection = null, IDataQueueHandler dataQueueHandler = null,
-            bool runPostInitialize = true)
+            bool runPostInitialize = true, IDataProvider dataProvider = null)
         {
             _algorithm.SetStartDate(_startDate);
             _algorithm.SetDateTime(_manualTimeProvider.GetUtcNow());
@@ -2988,7 +3087,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             _feed = new TestableLiveTradingDataFeed(_algorithm.Settings, dataQueueHandler ?? _dataQueueHandler);
             _feed.TestDataQueueHandlerManager.TimeProvider = _manualTimeProvider;
-            var fileProvider = TestGlobals.DataProvider;
+            var fileProvider = dataProvider ?? TestGlobals.DataProvider;
             var marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
             var symbolPropertiesDataBase = SymbolPropertiesDatabase.FromDataFolder();
             var securityService = new SecurityService(_algorithm.Portfolio.CashBook, marketHoursDatabase, symbolPropertiesDataBase, _algorithm, RegisteredSecurityDataTypesProvider.Null, new SecurityCacheProvider(_algorithm.Portfolio), algorithm: _algorithm);
@@ -3085,6 +3184,49 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         private class Count
         {
             public int Value;
+        }
+
+        private class BackupUniverseFileDataProvider : IDataProvider
+        {
+            private readonly IDataProvider _dataProvider = TestGlobals.DataProvider;
+            private readonly bool _hideUniverseFiles;
+
+            private int _universeFileRequests;
+            private int _backupUniverseFileRequests;
+
+            public int UniverseFileRequests => _universeFileRequests;
+            public int BackupUniverseFileRequests => _backupUniverseFileRequests;
+
+            public event EventHandler<DataProviderNewDataRequestEventArgs> NewDataRequest;
+
+            public BackupUniverseFileDataProvider(bool hideUniverseFiles)
+            {
+                _hideUniverseFiles = hideUniverseFiles;
+            }
+
+            public Stream Fetch(string key)
+            {
+                if (key.Contains("universes", StringComparison.InvariantCulture))
+                {
+                    if (key.EndsWith(".csv.backup", StringComparison.InvariantCulture))
+                    {
+                        Interlocked.Increment(ref _backupUniverseFileRequests);
+                        // serve the backup universe file contents from the actual universe file
+                        return _dataProvider.Fetch(key.Substring(0, key.Length - ".backup".Length));
+                    }
+
+                    if (key.EndsWith(".csv", StringComparison.InvariantCulture))
+                    {
+                        Interlocked.Increment(ref _universeFileRequests);
+                        if (_hideUniverseFiles)
+                        {
+                            return null;
+                        }
+                    }
+                }
+
+                return _dataProvider.Fetch(key);
+            }
         }
 
         private static IEnumerable<BaseData> ProduceBenchmarkTicks(FuncDataQueueHandler fdqh, Count count)

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -229,12 +229,6 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         public void LiveChainSelection(SecurityType securityType, Resolution resolution, int expirationDatesFilter, bool strictEndTimes)
         {
             _startDate = securityType == SecurityType.IndexOption ? new DateTime(2021, 1, 4) : new DateTime(2014, 6, 9);
-            if (securityType.IsOption())
-            {
-                // option chain universe files are only read while the market is open or close to opening,
-                // so we start within that window, half an hour before the market open (9:30 NY)
-                _startDate = _startDate.AddHours(securityType == SecurityType.IndexOption ? 14 : 13);
-            }
             _manualTimeProvider.SetCurrentTimeUtc(_startDate);
             var endDate = _startDate.AddDays(securityType == SecurityType.Future ? 5 : 1);
 
@@ -271,23 +265,20 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             }
             _algorithm.OnEndOfTimeStep();
 
-            var expectedSelections = securityType == SecurityType.Future ? 2 : 1;
-
             // allow time for the exchange to pick up the selection point
             Thread.Sleep(50);
             ConsumeBridge(feed, TimeSpan.FromSeconds(5), true, ts =>
             {
-                if (selectionHappened == expectedSelections)
+                if (selectionHappened == 2)
                 {
                     // we got what we wanted shortcut unit test
                     _manualTimeProvider.SetCurrentTimeUtc(Time.EndOfTime);
                 }
             },
             endDate: endDate,
-            // a slower time step for options so the simulated clock doesn't race past the universe file refresh window
-            // between the real-time custom exchange polls
-            secondsTimeStep: securityType == SecurityType.Future ? 60 * 60 : 60);
+            secondsTimeStep: 60 * 60);
 
+            var expectedSelections = securityType == SecurityType.Future ? 2 : 1;
             Assert.AreEqual(expectedSelections, selectionHappened);
         }
 
@@ -626,67 +617,6 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             Assert.AreEqual(startDateUtc, firstSelectionTimeUtc);
             Assert.GreaterOrEqual(timeSliceCount, 1);
-            Assert.IsNotNull(selectedSymbols);
-            Assert.IsNotEmpty(selectedSymbols);
-        }
-
-        [TestCase(SecurityType.Option)]
-        [TestCase(SecurityType.IndexOption)]
-        public void OptionChainSelectionIsDelayedUntilCloseToMarketOpen(SecurityType securityType)
-        {
-            // start the algorithm during the night: the universe file should not be read until close to the market open
-            _startDate = securityType == SecurityType.Option
-                ? new DateTime(2015, 12, 24, 2, 0, 0)
-                : new DateTime(2021, 01, 04, 2, 0, 0);
-            var startDateUtc = _startDate.ConvertToUtc(_algorithm.TimeZone);
-            _manualTimeProvider.SetCurrentTimeUtc(startDateUtc);
-            var endDate = _startDate.AddDays(1);
-
-            _algorithm.SetBenchmark(x => 1);
-
-            var feed = RunDataFeed(runPostInitialize: false);
-
-            var firstSelectionTimeUtc = DateTime.MinValue;
-            List<Symbol> selectedSymbols = null;
-
-            var option = securityType == SecurityType.Option
-                ? _algorithm.AddOption("GOOG")
-                : _algorithm.AddIndexOption("SPX");
-            option.SetFilter(universe =>
-            {
-                firstSelectionTimeUtc = universe.LocalTime.ConvertToUtc(option.Exchange.TimeZone);
-                selectedSymbols = (List<Symbol>)universe;
-
-                return universe;
-            });
-
-            _algorithm.PostInitialize();
-
-            // allow time for the exchange to pick up the selection point
-            Thread.Sleep(50);
-
-            // the timeout needs to be generous: the simulated clock advances one minute per loop iteration
-            // and it has several simulated hours to go through before the universe file refresh window is reached
-            ConsumeBridge(feed, TimeSpan.FromSeconds(30), true, ts =>
-            {
-                if (firstSelectionTimeUtc != default)
-                {
-                    // we got what we wanted shortcut unit test
-                    _manualTimeProvider.SetCurrentTimeUtc(Time.EndOfTime);
-                }
-            },
-            endDate: endDate,
-            secondsTimeStep: 60);
-
-            var exchangeHours = option.Exchange.Hours;
-            var marketOpenUtc = exchangeHours
-                .GetNextMarketOpen(startDateUtc.ConvertFromUtc(exchangeHours.TimeZone), extendedMarketHours: false)
-                .ConvertToUtc(exchangeHours.TimeZone);
-
-            Assert.AreNotEqual(DateTime.MinValue, firstSelectionTimeUtc);
-            // selection should have been delayed to at most one hour before the market open, instead of happening right away
-            Assert.GreaterOrEqual(firstSelectionTimeUtc, marketOpenUtc.AddHours(-1));
-            Assert.LessOrEqual(firstSelectionTimeUtc, marketOpenUtc);
             Assert.IsNotNull(selectedSymbols);
             Assert.IsNotEmpty(selectedSymbols);
         }

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -229,6 +229,12 @@ namespace QuantConnect.Tests.Engine.DataFeeds
         public void LiveChainSelection(SecurityType securityType, Resolution resolution, int expirationDatesFilter, bool strictEndTimes)
         {
             _startDate = securityType == SecurityType.IndexOption ? new DateTime(2021, 1, 4) : new DateTime(2014, 6, 9);
+            if (securityType.IsOption())
+            {
+                // option chain universe files are only read while the market is open or close to opening,
+                // so we start within that window, half an hour before the market open (9:30 NY)
+                _startDate = _startDate.AddHours(securityType == SecurityType.IndexOption ? 14 : 13);
+            }
             _manualTimeProvider.SetCurrentTimeUtc(_startDate);
             var endDate = _startDate.AddDays(securityType == SecurityType.Future ? 5 : 1);
 
@@ -265,20 +271,23 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             }
             _algorithm.OnEndOfTimeStep();
 
+            var expectedSelections = securityType == SecurityType.Future ? 2 : 1;
+
             // allow time for the exchange to pick up the selection point
             Thread.Sleep(50);
             ConsumeBridge(feed, TimeSpan.FromSeconds(5), true, ts =>
             {
-                if (selectionHappened == 2)
+                if (selectionHappened == expectedSelections)
                 {
                     // we got what we wanted shortcut unit test
                     _manualTimeProvider.SetCurrentTimeUtc(Time.EndOfTime);
                 }
             },
             endDate: endDate,
-            secondsTimeStep: 60 * 60);
+            // a slower time step for options so the simulated clock doesn't race past the universe file refresh window
+            // between the real-time custom exchange polls
+            secondsTimeStep: securityType == SecurityType.Future ? 60 * 60 : 60);
 
-            var expectedSelections = securityType == SecurityType.Future ? 2 : 1;
             Assert.AreEqual(expectedSelections, selectionHappened);
         }
 
@@ -656,7 +665,9 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             // allow time for the exchange to pick up the selection point
             Thread.Sleep(50);
 
-            ConsumeBridge(feed, TimeSpan.FromSeconds(15), true, ts =>
+            // the timeout needs to be generous: the simulated clock advances one minute per loop iteration
+            // and it has several simulated hours to go through before the universe file refresh window is reached
+            ConsumeBridge(feed, TimeSpan.FromSeconds(30), true, ts =>
             {
                 if (firstSelectionTimeUtc != default)
                 {

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -621,6 +621,65 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             Assert.IsNotEmpty(selectedSymbols);
         }
 
+        [TestCase(SecurityType.Option)]
+        [TestCase(SecurityType.IndexOption)]
+        public void OptionChainSelectionIsDelayedUntilCloseToMarketOpen(SecurityType securityType)
+        {
+            // start the algorithm during the night: the universe file should not be read until close to the market open
+            _startDate = securityType == SecurityType.Option
+                ? new DateTime(2015, 12, 24, 2, 0, 0)
+                : new DateTime(2021, 01, 04, 2, 0, 0);
+            var startDateUtc = _startDate.ConvertToUtc(_algorithm.TimeZone);
+            _manualTimeProvider.SetCurrentTimeUtc(startDateUtc);
+            var endDate = _startDate.AddDays(1);
+
+            _algorithm.SetBenchmark(x => 1);
+
+            var feed = RunDataFeed(runPostInitialize: false);
+
+            var firstSelectionTimeUtc = DateTime.MinValue;
+            List<Symbol> selectedSymbols = null;
+
+            var option = securityType == SecurityType.Option
+                ? _algorithm.AddOption("GOOG")
+                : _algorithm.AddIndexOption("SPX");
+            option.SetFilter(universe =>
+            {
+                firstSelectionTimeUtc = universe.LocalTime.ConvertToUtc(option.Exchange.TimeZone);
+                selectedSymbols = (List<Symbol>)universe;
+
+                return universe;
+            });
+
+            _algorithm.PostInitialize();
+
+            // allow time for the exchange to pick up the selection point
+            Thread.Sleep(50);
+
+            ConsumeBridge(feed, TimeSpan.FromSeconds(15), true, ts =>
+            {
+                if (firstSelectionTimeUtc != default)
+                {
+                    // we got what we wanted shortcut unit test
+                    _manualTimeProvider.SetCurrentTimeUtc(Time.EndOfTime);
+                }
+            },
+            endDate: endDate,
+            secondsTimeStep: 60);
+
+            var exchangeHours = option.Exchange.Hours;
+            var marketOpenUtc = exchangeHours
+                .GetNextMarketOpen(startDateUtc.ConvertFromUtc(exchangeHours.TimeZone), extendedMarketHours: false)
+                .ConvertToUtc(exchangeHours.TimeZone);
+
+            Assert.AreNotEqual(DateTime.MinValue, firstSelectionTimeUtc);
+            // selection should have been delayed to at most one hour before the market open, instead of happening right away
+            Assert.GreaterOrEqual(firstSelectionTimeUtc, marketOpenUtc.AddHours(-1));
+            Assert.LessOrEqual(firstSelectionTimeUtc, marketOpenUtc);
+            Assert.IsNotNull(selectedSymbols);
+            Assert.IsNotEmpty(selectedSymbols);
+        }
+
         [Test]
         public void CustomUniverseImmediateSelection()
         {

--- a/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
+++ b/Tests/Engine/DataFeeds/LiveTradingDataFeedTests.cs
@@ -283,16 +283,25 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             Assert.AreEqual(expectedSelections, selectionHappened);
         }
 
-        [TestCase(SecurityType.Option, false)]
-        [TestCase(SecurityType.Option, true)]
-        [TestCase(SecurityType.IndexOption, false)]
-        [TestCase(SecurityType.IndexOption, true)]
-        public void ChainSelectionFallsBackToBackupUniverseFileCloseToMarketOpen(SecurityType securityType, bool universeFileAvailable)
+        [TestCase("OptionChain", false)]
+        [TestCase("OptionChain", true)]
+        [TestCase("IndexOptionChain", false)]
+        [TestCase("IndexOptionChain", true)]
+        [TestCase("CoarseFundamental", false)]
+        [TestCase("CoarseFundamental", true)]
+        [TestCase("EtfConstituents", false)]
+        [TestCase("EtfConstituents", true)]
+        public void UniverseSelectionFallsBackToBackupUniverseFileCloseToMarketOpen(string universeKind, bool universeFileAvailable)
         {
             // start close to the market open (9:15 NY), within the backup universe file fallback window (30 minutes before the open by default)
-            _startDate = securityType == SecurityType.Option
-                ? new DateTime(2014, 6, 9, 13, 15, 0)
-                : new DateTime(2021, 1, 4, 14, 15, 0);
+            _startDate = universeKind switch
+            {
+                "OptionChain" => new DateTime(2014, 6, 9, 13, 15, 0),
+                "IndexOptionChain" => new DateTime(2021, 1, 4, 14, 15, 0),
+                "CoarseFundamental" => new DateTime(2014, 3, 26, 13, 15, 0),
+                "EtfConstituents" => new DateTime(2020, 12, 1, 14, 15, 0),
+                _ => throw new ArgumentException($"Unexpected universe kind: {universeKind}")
+            };
             _manualTimeProvider.SetCurrentTimeUtc(_startDate);
             var endDate = _startDate.AddDays(1);
 
@@ -302,17 +311,47 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             var feed = RunDataFeed(runPostInitialize: false, dataProvider: dataProvider);
 
             var selectionHappened = 0;
-            List<OptionUniverse> selectedContracts = null;
-            var option = securityType == SecurityType.Option
-                ? _algorithm.AddOption("AAPL")
-                : _algorithm.AddIndexOption("SPX");
-            option.SetFilter(universe =>
+            var selectedCount = 0;
+
+            IEnumerable<Symbol> CoarseFilter(IEnumerable<CoarseFundamental> coarse)
             {
                 selectionHappened++;
-                selectedContracts = universe.ToList();
+                var symbols = coarse.Select(x => x.Symbol).ToList();
+                selectedCount = symbols.Count;
+                return symbols;
+            }
 
-                return universe;
-            });
+            switch (universeKind)
+            {
+                case "OptionChain":
+                case "IndexOptionChain":
+                    var option = universeKind == "OptionChain"
+                        ? _algorithm.AddOption("AAPL")
+                        : _algorithm.AddIndexOption("SPX");
+                    option.SetFilter(universe =>
+                    {
+                        selectionHappened++;
+                        selectedCount = universe.Count();
+                        return universe;
+                    });
+                    break;
+
+                case "CoarseFundamental":
+                    _algorithm.UniverseSettings.Resolution = Resolution.Daily;
+                    _algorithm.AddUniverse(CoarseFilter);
+                    break;
+
+                case "EtfConstituents":
+                    var spy = _algorithm.AddEquity("SPY").Symbol;
+                    _algorithm.AddUniverse(_algorithm.Universe.ETF(spy, constituentsData =>
+                    {
+                        selectionHappened++;
+                        var symbols = constituentsData.Select(x => x.Symbol).ToList();
+                        selectedCount = symbols.Count;
+                        return symbols;
+                    }));
+                    break;
+            }
 
             _algorithm.PostInitialize();
 
@@ -331,8 +370,7 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             secondsTimeStep: 60);
 
             Assert.AreEqual(1, selectionHappened);
-            Assert.IsNotNull(selectedContracts);
-            Assert.IsNotEmpty(selectedContracts);
+            Assert.AreNotEqual(0, selectedCount);
 
             if (universeFileAvailable)
             {
@@ -3206,7 +3244,9 @@ namespace QuantConnect.Tests.Engine.DataFeeds
 
             public Stream Fetch(string key)
             {
-                if (key.Contains("universes", StringComparison.InvariantCulture))
+                // coarse fundamental files are universe files too, they just don't live under a "universes" folder
+                if (key.Contains("universes", StringComparison.InvariantCulture)
+                    || key.Replace('\\', '/').Contains("fundamental/coarse", StringComparison.InvariantCulture))
                 {
                     if (key.EndsWith(".csv.backup", StringComparison.InvariantCulture))
                     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description

In live trading, file-based universe selection (option and futures chains, coarse fundamental, ETF constituents) depends on the daily universe file for the previous tradable date being on disk. If the data pipeline hasn't produced that file yet by the time the market is about to open, selection silently doesn't happen.

The change adds a safety net: a backup universe file (`<universe file>.backup`), when present, is used as a last resort:

- `LiveCustomDataSubscriptionEnumeratorFactory` owns the fallback, enabled with a new opt-in `fallBackToBackupUniverseFiles` constructor flag (off by default, so custom data and custom universe subscriptions never touch backup files). On each rate-limited refresh, for `LocalFile` sources inside the fallback window, the source is read through a `BackupUniverseFileDataProvider` wrapper whose `Fetch` tries the expected file and only on a miss the `.backup` one — so the expected file is fetched exactly once when present, and the backup is only fetched when it isn't.
- `LiveTradingDataFeed.CreateUniverseSubscription` enables it for every universe served by the file-based branch: option chains, futures chains, fundamental/coarse and ETF constituents.
- When the market is open or within `universe-file-backup-fallback-minutes` (new config, default 30) of the next market open, if the expected universe file can't be fetched, the subscription falls back to `<file>.backup` (logged).
- The expected file is always preferred and re-checked on every refresh; far from market open no backup probing happens.

#### Related Issue

N/A

#### Motivation and Context

The daily chain universe files are written by a data pipeline shortly before the market opens. If a file is late or missing, live algorithms get no chain selection for the day. With this change, a previously generated backup file keeps selection working until the expected file shows up.

#### Requires Documentation Change

No

#### How Has This Been Tested?

- New `LiveCustomDataSubscriptionEnumeratorFactoryTests`: `FallsBackToBackupUniverseFileWhenExpectedSourceIsNotAvailable` (a single fetch of the expected file plus one of the backup on a miss, rate limited like refreshes, and the expected file preferred again once available without touching the backup), `DoesNotFallBackToBackupUniverseFileFarFromMarketOpen` and `DoesNotFallBackToBackupUniverseFileWhenNotConfigured` (the backup file is never fetched in either case).
- New `LiveTradingDataFeedTests.UniverseSelectionFallsBackToBackupUniverseFileCloseToMarketOpen`: 8 cases — equity option chain, index option chain, coarse fundamental and ETF constituents universes, each with the expected file available and missing. Selection succeeds from the backup only when the expected file is missing; the backup is never touched when the expected file exists.
- New `LiveTradingDataFeedTests.ChainSelectionDoesNotFallBackToBackupUniverseFileFarFromMarketOpen`: no backup probing outside the pre-open window (the gating is shared by all universe types).
- All 30 existing `LiveChainSelection` cases, the full `LiveCustomDataSubscriptionEnumeratorFactoryTests` fixture, and the `*ImmediateSelection`/`FundamentalScheduleSelection` tests pass; the new feed-level tests passed repeat runs with no flakiness.
- Live-paper deployment (local Launcher, `FakeDataQueue`, test-only shifted engine clock, fabricated GOOG universe files): deployed pre-open with only a backup file on disk, the backup was correctly not probed outside the window, then read on the first refresh inside it — the option filter selected all 2192 contracts from the backup, zero errors.
- Second live-paper deployment with both files on disk (backup trimmed to 20 contracts as a decoy) and a 1-minute refresh cadence: selection used the expected file (2192 contracts) immediately, and across ~6 refresh cycles the backup was never probed, zero errors.
- The same live-paper deployment pair for a coarse fundamental universe: with only a backup coarse file on disk, the first refresh outside the pre-open window correctly read nothing and the first refresh inside it fell back and selected from the backup; with both files on disk, selection used the expected file (7068 entries, not the 20-row decoy backup) within seconds of deployment and the backup was never probed.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
