### PR TITLE
Restore Python's builtin Exception shadowed by AlgorithmImports star imports

### DIFF
--- a/Common/AlgorithmImports.py
+++ b/Common/AlgorithmImports.py
@@ -29,6 +29,7 @@ for file in os.listdir(path):
     if file.endswith(".dll") and file.startswith("QuantConnect."):
         AddReference(file.replace(".dll", ""))
 
+import System
 from System import *
 from System.Drawing import *
 
@@ -98,6 +99,12 @@ from datetime import date, time, datetime, timedelta
 from typing import *
 import math
 import json
+
+# "from System import *" shadows Python's builtin Exception with System.Exception, whose
+# except clauses do not catch Python exceptions (TypeError, KeyError, ...).
+# Restore the builtin; the CLR type remains available as System.Exception.
+import builtins
+Exception = builtins.Exception
 
 QCAlgorithmFramework = QCAlgorithm
 QCAlgorithmFrameworkBridge = QCAlgorithm

--- a/Common/AlgorithmImports.py
+++ b/Common/AlgorithmImports.py
@@ -103,8 +103,7 @@ import json
 # "from System import *" shadows Python's builtin Exception with System.Exception, whose
 # except clauses do not catch Python exceptions (TypeError, KeyError, ...).
 # Restore the builtin; the CLR type remains available as System.Exception.
-import builtins
-Exception = builtins.Exception
+from builtins import Exception
 
 QCAlgorithmFramework = QCAlgorithm
 QCAlgorithmFrameworkBridge = QCAlgorithm

--- a/Common/AlgorithmImports.py
+++ b/Common/AlgorithmImports.py
@@ -29,7 +29,6 @@ for file in os.listdir(path):
     if file.endswith(".dll") and file.startswith("QuantConnect."):
         AddReference(file.replace(".dll", ""))
 
-import System
 from System import *
 from System.Drawing import *
 
@@ -102,7 +101,7 @@ import json
 
 # "from System import *" shadows Python's builtin Exception with System.Exception, whose
 # except clauses do not catch Python exceptions (TypeError, KeyError, ...).
-# Restore the builtin; the CLR type remains available as System.Exception.
+# Restore the builtin; "import System" gives explicit access to the CLR type if needed.
 from builtins import Exception
 
 QCAlgorithmFramework = QCAlgorithm

--- a/Tests/Python/AlgorithmImportsTests.cs
+++ b/Tests/Python/AlgorithmImportsTests.cs
@@ -1,0 +1,111 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using Python.Runtime;
+using NUnit.Framework;
+
+namespace QuantConnect.Tests.Python
+{
+    [TestFixture]
+    public class AlgorithmImportsTests
+    {
+        private PyObject _module;
+
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            using (Py.GIL())
+            {
+                _module = PyModule.FromString("AlgorithmImportsTests", @"
+from AlgorithmImports import *
+import builtins
+import AlgorithmImports
+
+def exception_is_the_python_builtin():
+    return Exception is builtins.Exception
+
+def except_clause_catches_python_exceptions():
+    try:
+        raise TypeError('expected')
+    except Exception:
+        return True
+    except BaseException:
+        return False
+
+def except_clause_catches_clr_exceptions(action):
+    try:
+        action()
+    except Exception:
+        return True
+    except BaseException:
+        return False
+
+def shadowed_builtin_names():
+    return [name for name, value in vars(AlgorithmImports).items()
+            if not name.startswith('_') and getattr(builtins, name, value) is not value]
+");
+            }
+        }
+
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            using (Py.GIL())
+            {
+                _module.Dispose();
+            }
+        }
+
+        [Test]
+        public void ExceptionIsThePythonBuiltinException()
+        {
+            using (Py.GIL())
+            {
+                Assert.IsTrue(_module.GetAttr("exception_is_the_python_builtin").Invoke().As<bool>());
+            }
+        }
+
+        [Test]
+        public void ExceptClauseCatchesPythonExceptions()
+        {
+            using (Py.GIL())
+            {
+                Assert.IsTrue(_module.GetAttr("except_clause_catches_python_exceptions").Invoke().As<bool>());
+            }
+        }
+
+        [Test]
+        public void ExceptClauseCatchesClrExceptions()
+        {
+            using (Py.GIL())
+            {
+                Action action = () => throw new ArgumentException("thrown from C#");
+                Assert.IsTrue(_module.GetAttr("except_clause_catches_clr_exceptions").Invoke(action.ToPython()).As<bool>());
+            }
+        }
+
+        [Test]
+        public void StarImportsDoNotShadowPythonBuiltins()
+        {
+            using (Py.GIL())
+            {
+                var shadowed = _module.GetAttr("shadowed_builtin_names").Invoke().As<string[]>();
+                Assert.IsEmpty(shadowed, $"Python builtins shadowed by AlgorithmImports: {string.Join(", ", shadowed)}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Description

`AlgorithmImports.py` does `from System import *`, which shadows Python's builtin `Exception` with `System.Exception`. Pure-Python exceptions (`TypeError`, `KeyError`, ...) do not derive from it, so `except Exception:` silently fails to catch them:

```python
try:
    self.history(...)  # raises TypeError
except Exception as e:  # actually System.Exception -> does NOT catch
    self.log(f"handled: {e}")
```

The fix restores the builtin after the star imports:

- `from builtins import Exception` at the end of `AlgorithmImports.py`. The builtin also catches CLR exceptions raised into Python, so it is strictly broader than the previous binding.
- Algorithms that want the CLR type explicitly can `import System` and catch `System.Exception`.

Behavior changes: `raise Exception("msg")` now creates a Python `Exception` instead of a `System.Exception` (both propagate and log fine), and `isinstance(x, Exception)` is broader.

#### Related Issue

N/A

#### Motivation and Context

Python algorithms commonly wrap calls in `try/except Exception` and still crash with "unhandled" `TypeError`/`KeyError`. The code is idiomatic Python and correct anywhere except inside Lean.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

New `Tests/Python/AlgorithmImportsTests` fixture, written red-first against master:

- `ExceptionIsThePythonBuiltinException` — `Exception is builtins.Exception` after `from AlgorithmImports import *`.
- `ExceptClauseCatchesPythonExceptions` — `except Exception:` catches a raised `TypeError`.
- `ExceptClauseCatchesClrExceptions` — `except Exception:` still catches a CLR exception thrown from C# (no regression).
- `StarImportsDoNotShadowPythonBuiltins` — audits every exported name against `builtins`; before the fix it reported exactly `Exception`, now empty. Guards against future shadowing.

Full `QuantConnect.Tests.Python` and `QuantConnect.Tests.Common.Exceptions` fixtures (1458 tests): all green.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

