### PR TITLE
Reset the MidPrice rolling extremes

### DIFF
--- a/Indicators/MidPrice.cs
+++ b/Indicators/MidPrice.cs
@@ -72,5 +72,15 @@ namespace QuantConnect.Indicators
 
             return (_maximum.Current.Value + _minimum.Current.Value) / 2;
         }
+
+        /// <summary>
+        /// Resets this indicator to its initial state
+        /// </summary>
+        public override void Reset()
+        {
+            _maximum.Reset();
+            _minimum.Reset();
+            base.Reset();
+        }
     }
 }

--- a/Tests/Indicators/MidPriceTests.cs
+++ b/Tests/Indicators/MidPriceTests.cs
@@ -13,6 +13,8 @@
  * limitations under the License.
 */
 
+using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
@@ -35,6 +37,36 @@ namespace QuantConnect.Tests.Indicators
         protected override string TestColumnName
         {
             get { return "MIDPRICE_5"; }
+        }
+
+        [Test]
+        public void ProducesTheSameValuesAfterReset()
+        {
+            var midPrice = new MidPrice(3);
+            var reference = new DateTime(2024, 1, 1);
+            var bars = new[]
+            {
+                new TradeBar { High = 110m, Low = 100m },
+                new TradeBar { High = 111m, Low = 101m },
+                new TradeBar { High = 112m, Low = 102m },
+                new TradeBar { High = 105m, Low = 95m }
+            };
+
+            var expected = new List<decimal>();
+            for (var i = 0; i < bars.Length; i++)
+            {
+                bars[i].Time = reference.AddDays(i);
+                midPrice.Update(bars[i]);
+                expected.Add(midPrice.Current.Value);
+            }
+
+            midPrice.Reset();
+
+            for (var i = 0; i < bars.Length; i++)
+            {
+                midPrice.Update(bars[i]);
+                Assert.AreEqual(expected[i], midPrice.Current.Value);
+            }
         }
     }
 }


### PR DESCRIPTION
#### Description

MidPrice never overrode Reset(), so its Maximum and Minimum carried the previous run.

#### Related Issue

Closes #9693

#### Motivation and Context

The first bars after a reset were computed from data outside the window. Same class as #9686, #9687 and #9688.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

Added ProducesTheSameValuesAfterReset to MidPriceTests, in the shape used in ConnorsRelativeStrengthIndexTests and SuperTrendTests. It fails on master and passes with the override.

Also ran the indicator against Tests/TestData/spy_midprice.txt on a master build and on this one: 496 expected MIDPRICE_5 values, no mismatches either way, so nothing outside the reset path moves.

My local NUnit host crashes on a Python.NET finalizer during test discovery, unrelated to this change, so both runs above were done from a console program linked against each build rather than through `dotnet test`.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed. <!-- see How Has This Been Tested: the local NUnit host will not start -->
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
