### PR TITLE
Ignore zero quantity open orders in brokerage setup

### DIFF
--- a/Engine/Setup/BrokerageSetupHandler.cs
+++ b/Engine/Setup/BrokerageSetupHandler.cs
@@ -487,9 +487,21 @@ namespace QuantConnect.Lean.Engine.Setup
             // populate the algorithm with the account's outstanding orders
             var openOrders = brokerage.GetOpenOrders();
 
+            var zeroQuantityWarningSent = false;
             // add options first to ensure raw data normalization mode is set on the equity underlyings
             foreach (var order in openOrders.OrderByDescending(x => x.SecurityType))
             {
+                if (order.Quantity == 0)
+                {
+                    Log.Trace($"BrokerageSetupHandler.Setup(): Ignoring open order with zero quantity: {order}");
+                    if (!zeroQuantityWarningSent)
+                    {
+                        zeroQuantityWarningSent = true;
+                        resultHandler.DebugMessage($"Ignoring open {order.Type} order '{string.Join(",", order.BrokerId)}' for {order.Symbol.Value} with zero quantity, please double check your holdings.");
+                    }
+                    continue;
+                }
+
                 // verify existing holding security type
                 Security security;
                 if (!GetOrAddUnrequestedSecurity(algorithm, order.Symbol, order.SecurityType, out security))

--- a/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
+++ b/Tests/Engine/Setup/BrokerageSetupHandlerTests.cs
@@ -94,8 +94,9 @@ namespace QuantConnect.Tests.Engine.Setup
                 Assert.AreEqual(OrderStatus.Submitted, order.Status);
             }
 
-            // Warn the user about each open order
-            Assert.AreEqual(_resultHandler.PersistentMessages.Count, 4);
+            // Warn the user about each open order, plus a single warning for the two zero quantity orders
+            Assert.AreEqual(_resultHandler.PersistentMessages.Count, 5);
+            Assert.AreEqual(1, _resultHandler.PersistentMessages.Count(x => ((DebugPacket)x).Message.Contains("zero quantity", StringComparison.InvariantCulture)));
 
             // Market order
             Assert.AreEqual(_transactionHandler.OrderTickets.First(x => x.Value.OrderType == OrderType.Market).Value.Quantity, 100);
@@ -965,7 +966,10 @@ namespace QuantConnect.Tests.Engine.Setup
                 marketOrderWithPrice,
                 new LimitOrder(Symbols.SPY, -quantity, pricePlusDelta, time),
                 new StopMarketOrder(Symbols.SPY, quantity, pricePlusDelta, time),
-                new StopLimitOrder(Symbols.SPY, quantity, pricePlusDelta, priceMinusDelta, time)
+                new StopLimitOrder(Symbols.SPY, quantity, pricePlusDelta, priceMinusDelta, time),
+                // orders with zero quantity should be ignored, with a single user warning
+                new LimitOrder(Symbols.SPY, 0, pricePlusDelta, time) { BrokerId = new List<string> { "zero-qty-1" } },
+                new MarketOrder(Symbols.SPY, 0, time) { BrokerId = new List<string> { "zero-qty-2" } }
             };
         }
 


### PR DESCRIPTION
#### Description

`BrokerageSetupHandler.GetOpenOrders()` now skips open orders reported by the brokerage with zero quantity, since they don't make sense and would create invalid order tickets. Each skipped order is logged, and a single user-facing warning is sent for the first occurrence:

> Ignoring open {Type} order '{broker id}' for {symbol} with zero quantity, please double check your holdings.

The check runs before security resolution, so no unrequested security is added for ignored orders.

#### Testing

`CanGetOpenOrders` updated: the test brokerage now returns two additional zero quantity orders, asserting they produce no orders/tickets and that the warning is emitted only once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)