### PR TITLE
Compare the replayed bars in ResetWorksAsExpected

### DIFF
--- a/Tests/Common/Data/BaseConsolidatorTests.cs
+++ b/Tests/Common/Data/BaseConsolidatorTests.cs
@@ -31,6 +31,11 @@ namespace QuantConnect.Tests.Common.Data
     {
         protected abstract IDataConsolidator CreateConsolidator();
 
+        /// <summary>
+        /// Whether the test values are expected to close at least one bar
+        /// </summary>
+        protected virtual bool EmitsConsolidatedBars => true;
+
         protected virtual void AssertConsolidator(IDataConsolidator consolidator)
         {
             Assert.IsNull(consolidator.Consolidated);
@@ -102,7 +107,14 @@ namespace QuantConnect.Tests.Common.Data
             }
 
             Assert.AreEqual(consolidatedBarsBefore.Count, consolidatedBarsAfter.Count);
-            consolidatedBarsBefore.Zip<IBaseData, IBaseData, bool>(consolidatedBarsAfter, AssertConsolidatedValues);
+            if (EmitsConsolidatedBars)
+            {
+                CollectionAssert.IsNotEmpty(consolidatedBarsBefore);
+            }
+            foreach (var (before, after) in consolidatedBarsBefore.Zip(consolidatedBarsAfter))
+            {
+                AssertConsolidatedValues(before, after);
+            }
             consolidator.Dispose();
         }
     }

--- a/Tests/Common/Data/MarketHourAwareConsolidatorTests.cs
+++ b/Tests/Common/Data/MarketHourAwareConsolidatorTests.cs
@@ -448,6 +448,8 @@ namespace QuantConnect.Tests.Common.Data
                 new TradeBar(){ Time = time.AddMinutes(8), Period = Time.OneMinute, Symbol = Symbols.SPY, High = 25 },
                 new TradeBar(){ Time = time.AddMinutes(9), Period = Time.OneMinute, Symbol = Symbols.SPY, High = 30 },
                 new TradeBar(){ Time = time.AddMinutes(10), Period = Time.OneMinute, Symbol = Symbols.SPY, High = 26 },
+                new TradeBar(){ Time = time.AddHours(1), Period = Time.OneMinute, Symbol = Symbols.SPY, High = 31 },
+                new TradeBar(){ Time = time.AddHours(2), Period = Time.OneMinute, Symbol = Symbols.SPY, High = 27 },
             };
         }
 

--- a/Tests/Common/Data/OpenInterestConsolidatorTests.cs
+++ b/Tests/Common/Data/OpenInterestConsolidatorTests.cs
@@ -81,6 +81,8 @@ namespace QuantConnect.Tests.Common.Data
                 new OpenInterest(){ Time = time.AddMinutes(8), Symbol = Symbols.SPY, Value = 25 },
                 new OpenInterest(){ Time = time.AddMinutes(9), Symbol = Symbols.SPY, Value = 30 },
                 new OpenInterest(){ Time = time.AddMinutes(10), Symbol = Symbols.SPY, Value = 26 },
+                new OpenInterest(){ Time = time.AddDays(1), Symbol = Symbols.SPY, Value = 31 },
+                new OpenInterest(){ Time = time.AddDays(2), Symbol = Symbols.SPY, Value = 27 },
             };
         }
 

--- a/Tests/Python/DataConsolidatorPythonWrapperTests.cs
+++ b/Tests/Python/DataConsolidatorPythonWrapperTests.cs
@@ -400,6 +400,8 @@ namespace QuantConnect.Tests.Python
 
         }
 
+        protected override bool EmitsConsolidatedBars => false;
+
         protected override IEnumerable<IBaseData> GetTestValues()
         {
             var time = DateTime.Today;


### PR DESCRIPTION
#### Description
ResetWorksAsExpected discarded a lazy Zip, so AssertConsolidatedValues never ran and only the bar counts were compared.

#### Related Issue
#9699

#### Motivation and Context
The test is the only reset coverage the 16 consolidator fixtures share. Deleting `_workingBar = null;` from PeriodCountConsolidatorBase.Reset() leaves a real state leak in the base class most consolidators derive from, and on master the test still passes 17 of 17. With the comparison enumerated it fails.

Three fixtures also produced no consolidated bars at all, so there was nothing to compare even once the comparison runs. OpenInterest consolidates daily and fed 11 minutes; MarketHourAware consolidates hourly and fed 11 minutes. Both now cross a period boundary. The python wrapper fixture never sets consolidated on purpose, so it declares that instead.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
Putting `Assert.Fail` as the first line of AssertConsolidatedValues passes 17 of 17 on master, which is the bug. With this change the same planted `_workingBar` leak turns ResetWorksAsExpected red and reverting it turns it green.

All 17 fixtures pass with the comparison running.

Full suite, `--filter "TestCategory!=TravisExclude&TestCategory!=ResearchRegressionTests"`: 36614 tests, 4 failures, against 3 on master. CommanCallback(Python) and ZipBytesReturnsByteArrayWithCorrectLength fail on both. The other three, ThreadSafety, DoesNotLeak and MultiThreadReadWriteTest, alternate between runs and all pass in isolation; none of them touches a consolidator.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>`
