### PR TITLE
Suggest enabling performance tracking in the speed analysis findings

### DIFF
--- a/Engine/Results/Analysis/Analyses/AlgorithmSpeedAnalysis.cs
+++ b/Engine/Results/Analysis/Analyses/AlgorithmSpeedAnalysis.cs
@@ -125,7 +125,9 @@ namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses
         /// Runs the algorithm speed analysis against the speed metrics tracked for the backtest,
         /// falling back to the completion log line when they cannot measure the speed.
         /// </summary>
-        public override IReadOnlyList<QuantConnect.Analysis> Run(ResultsAnalysisRunParameters parameters) => Run(parameters.Speed, parameters.Logs);
+        public override IReadOnlyList<QuantConnect.Analysis> Run(ResultsAnalysisRunParameters parameters)
+            => Run(parameters.Speed, parameters.Logs, parameters.Language,
+                performanceTrackingEnabled: parameters.Algorithm?.Settings.PerformanceSamplePeriod > TimeSpan.Zero);
 
         /// <summary>
         /// Runs the algorithm speed analysis against the given speed metrics.
@@ -138,22 +140,26 @@ namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses
         /// </summary>
         /// <param name="speed">The speed metrics tracked for the running backtest, or null when not tracked.</param>
         /// <param name="logs">The log lines to search for the completion line, or null when not available.</param>
+        /// <param name="language">The programming language the algorithm is written in.</param>
+        /// <param name="performanceTrackingEnabled">Whether the algorithm already has performance tracking enabled,
+        /// so the findings don't suggest enabling it again.</param>
         /// <returns>The failed sub-findings, or empty when no speed condition failed or none could be measured.</returns>
-        public IReadOnlyList<QuantConnect.Analysis> Run(AlgorithmSpeedTracker speed, IReadOnlyList<string> logs = null)
+        public IReadOnlyList<QuantConnect.Analysis> Run(AlgorithmSpeedTracker speed, IReadOnlyList<string> logs = null,
+            Language language = Language.CSharp, bool performanceTrackingEnabled = false)
         {
             var findings = new List<QuantConnect.Analysis>();
             var speedMeasured = false;
             if (speed != null && speed.SampledSpan >= MinimumSampledSpan)
             {
-                speedMeasured = AddSlowExecution(speed, findings);
+                speedMeasured = AddSlowExecution(speed, findings, language, performanceTrackingEnabled);
                 AddLongProjectedRuntime(speed, findings);
-                AddThroughputDegradation(speed, findings);
+                AddThroughputDegradation(speed, findings, language, performanceTrackingEnabled);
                 AddHistoryRequestLoad(speed, findings);
             }
 
             if (!speedMeasured)
             {
-                AddSlowExecutionFromCompletionLog(logs, findings);
+                AddSlowExecutionFromCompletionLog(logs, findings, language, performanceTrackingEnabled);
             }
 
             return CreateAggregatedResponse(findings);
@@ -163,7 +169,8 @@ namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses
         /// Reports slow execution when the recent data points per second are below the platform benchmark.
         /// </summary>
         /// <returns>Whether the speed could be measured, regardless of it being slow or not.</returns>
-        private static bool AddSlowExecution(AlgorithmSpeedTracker speed, List<QuantConnect.Analysis> findings)
+        private static bool AddSlowExecution(AlgorithmSpeedTracker speed, List<QuantConnect.Analysis> findings,
+            Language language, bool performanceTrackingEnabled)
         {
             if (!speed.HasDataPointCounts)
             {
@@ -208,6 +215,8 @@ namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses
                 [
                     "Review the algorithm code for inefficiencies.",
 
+                    .. PerformanceTrackingSolutions(language, performanceTrackingEnabled),
+
                     "If there is a universe, reduce its size.",
 
                     "Reduce the data resolution.",
@@ -225,7 +234,8 @@ namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses
         /// logged once the backtest ends, so in-run log deltas never match and the fallback can
         /// only fire on the final analysis.
         /// </summary>
-        private static void AddSlowExecutionFromCompletionLog(IReadOnlyList<string> logs, List<QuantConnect.Analysis> findings)
+        private static void AddSlowExecutionFromCompletionLog(IReadOnlyList<string> logs, List<QuantConnect.Analysis> findings,
+            Language language, bool performanceTrackingEnabled)
         {
             for (var i = (logs?.Count ?? 0) - 1; i >= 0; i--)
             {
@@ -246,6 +256,8 @@ namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses
                         null,
                         [
                             "Review the algorithm code for inefficiencies.",
+
+                            .. PerformanceTrackingSolutions(language, performanceTrackingEnabled),
 
                             "If there is a universe, reduce its size.",
 
@@ -315,7 +327,8 @@ namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses
         /// <see cref="DegradationRatio"/> of the early-run baseline. Requires enough samples for the
         /// baseline and recent windows to not overlap.
         /// </summary>
-        private static void AddThroughputDegradation(AlgorithmSpeedTracker speed, List<QuantConnect.Analysis> findings)
+        private static void AddThroughputDegradation(AlgorithmSpeedTracker speed, List<QuantConnect.Analysis> findings,
+            Language language, bool performanceTrackingEnabled)
         {
             if (!speed.HasDataPointCounts || speed.SampleCount < 2 * AlgorithmSpeedTracker.RecentWindowSamples + 1)
             {
@@ -344,6 +357,8 @@ namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses
                     "If there is a universe, check whether the number of selected securities keeps growing; remove securities that are no longer used.",
 
                     "Check the algorithm's memory usage: sustained growth causes garbage collection pressure that slows the whole run down.",
+
+                    .. PerformanceTrackingSolutions(language, performanceTrackingEnabled),
                 ]));
         }
 
@@ -372,6 +387,27 @@ namespace QuantConnect.Lean.Engine.Results.Analysis.Analyses
 
                     "Reduce the period or resolution of the history requests.",
                 ]));
+        }
+
+        /// <summary>
+        /// The performance tracking suggestion shared by the findings whose diagnosis needs to locate
+        /// where the execution time is spent: setting <see cref="AlgorithmSettings.PerformanceSamplePeriod"/>
+        /// adds a "Performance" chart with the engine's time breakdown on the next run.
+        /// Empty when the algorithm already has performance tracking enabled.
+        /// </summary>
+        private static IEnumerable<string> PerformanceTrackingSolutions(Language language, bool performanceTrackingEnabled)
+        {
+            if (performanceTrackingEnabled)
+            {
+                yield break;
+            }
+
+            yield return $"To see where the execution time is spent, set the " +
+                $"`{FormatCode(nameof(AlgorithmSettings.PerformanceSamplePeriod), language)}` setting, like " +
+                (language == Language.Python
+                    ? "`self.settings.performance_sample_period = timedelta(days=1)`"
+                    : "`Settings.PerformanceSamplePeriod = TimeSpan.FromDays(1);`") +
+                ", and rerun to get a \"Performance\" time-breakdown chart.";
         }
 
         /// <summary>

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -232,7 +232,10 @@ namespace QuantConnect.Lean.Engine.Results
                         runtimeStatistics,
                         new Dictionary<string, AlgorithmPerformance>(),
                         // we store the last 100 order events, the final packet will contain the full list
-                        TransactionHandler.OrderEvents.Reverse().Take(100).ToList(), state: GetAlgorithmState()));
+                        TransactionHandler.OrderEvents.Reverse().Take(100).ToList(), state: GetAlgorithmState()))
+                    {
+                        ServerStatistics = serverStatistics
+                    };
 
                     if (RunResultsAnalysis)
                     {

--- a/Tests/Engine/Results/AlgorithmSpeedAnalysisTests.cs
+++ b/Tests/Engine/Results/AlgorithmSpeedAnalysisTests.cs
@@ -286,6 +286,62 @@ namespace QuantConnect.Tests.Engine.Results
         }
 
         [Test]
+        public void SlowFindingsSuggestEnablingPerformanceTracking()
+        {
+            // Both slow and degrading: the slow execution and the degradation findings carry the suggestion
+            var tracker = new AlgorithmSpeedTracker();
+            var dataPoints = 0L;
+            for (var i = 0; i < 12; i++)
+            {
+                tracker.AddSample(new(TimeSpan.FromSeconds(30 * i), dataPoints, 0, 0, 0));
+                dataPoints += i < 6 ? 3_000_000 : 300_000;
+            }
+
+            var findings = new AlgorithmSpeedAnalysis().Run(tracker);
+
+            Assert.AreEqual(2, findings.Count);
+            foreach (var finding in findings)
+            {
+                Assert.IsTrue(finding.Solutions.Any(solution =>
+                    solution.Contains(nameof(AlgorithmSettings.PerformanceSamplePeriod), StringComparison.Ordinal)));
+            }
+
+            // The completion log fallback carries it too
+            var fallbackFinding = new AlgorithmSpeedAnalysis().Run(null, new[] { SlowCompletionLogLine }).Single();
+            Assert.IsTrue(fallbackFinding.Solutions.Any(solution =>
+                solution.Contains(nameof(AlgorithmSettings.PerformanceSamplePeriod), StringComparison.Ordinal)));
+        }
+
+        [Test]
+        public void PerformanceTrackingSuggestionFollowsTheAlgorithmLanguage()
+        {
+            var tracker = AlgorithmSpeedTrackerTests.BuildUniformTracker(samples: 7, stepSeconds: 30,
+                dataPointsPerStep: 300_000, historyDataPointsPerStep: 0, daysPerStep: 1, totalDays: 10);
+
+            var finding = new AlgorithmSpeedAnalysis().Run(tracker, language: Language.Python).Single();
+
+            var solution = finding.Solutions.Single(solution => solution.Contains("performance_sample_period", StringComparison.Ordinal));
+            StringAssert.Contains("self.settings.performance_sample_period", solution);
+        }
+
+        [Test]
+        public void NoPerformanceTrackingSuggestionWhenAlreadyEnabled()
+        {
+            var tracker = AlgorithmSpeedTrackerTests.BuildUniformTracker(samples: 7, stepSeconds: 30,
+                dataPointsPerStep: 300_000, historyDataPointsPerStep: 0, daysPerStep: 1, totalDays: 10);
+
+            var finding = new AlgorithmSpeedAnalysis().Run(tracker, performanceTrackingEnabled: true).Single();
+
+            Assert.IsFalse(finding.Solutions.Any(solution =>
+                solution.Contains(nameof(AlgorithmSettings.PerformanceSamplePeriod), StringComparison.Ordinal)));
+
+            var fallbackFinding = new AlgorithmSpeedAnalysis()
+                .Run(null, new[] { SlowCompletionLogLine }, performanceTrackingEnabled: true).Single();
+            Assert.IsFalse(fallbackFinding.Solutions.Any(solution =>
+                solution.Contains(nameof(AlgorithmSettings.PerformanceSamplePeriod), StringComparison.Ordinal)));
+        }
+
+        [Test]
         public void NoHistoryLoadFindingBelowTheMinimumHistoryDataPointCount()
         {
             // 60% history share, but only a few hundred history data points in the window


### PR DESCRIPTION
## Description

- The algorithm speed analysis now suggests setting the `PerformanceSamplePeriod` setting to get the Performance chart with the engine time breakdown. The hint is added to the slow execution (tracked metrics and completion-log fallback) and throughput degradation findings, uses the algorithm's language for the setting name and example, and is skipped when the algorithm already has performance tracking enabled.
- Include the server statistics in the stored intermediate backtest results, matching the split update packets which already carry them.

## Related Issue

N/A

## Motivation and Context

Helps users diagnose slow backtests by pointing them at the built-in performance tracking tool.

## Requires Documentation Change

N/A

## How Has This Been Tested?

New unit tests in `AlgorithmSpeedAnalysisTests` covering the hint's presence, language formatting, and suppression when tracking is already enabled.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)