### PR TITLE
Reset the IntradayVwap running sums

### DIFF
--- a/Indicators/IntradayVwap.cs
+++ b/Indicators/IntradayVwap.cs
@@ -72,6 +72,17 @@ namespace QuantConnect.Indicators
         }
 
         /// <summary>
+        /// Resets this indicator to its initial state
+        /// </summary>
+        public override void Reset()
+        {
+            _lastDate = default;
+            _sumOfVolume = 0m;
+            _sumOfPriceTimesVolume = 0m;
+            base.Reset();
+        }
+
+        /// <summary>
         /// Determines the volume and price to be used for the current input in the VWAP computation
         /// </summary>
         protected bool TryGetVolumeAndAveragePrice(BaseData input, out decimal volume, out decimal averagePrice)

--- a/Tests/Indicators/IntradayVwapTests.cs
+++ b/Tests/Indicators/IntradayVwapTests.cs
@@ -1,0 +1,96 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Indicators;
+
+namespace QuantConnect.Tests.Indicators
+{
+    [TestFixture]
+    public class IntradayVwapTests
+    {
+        private static TradeBar[] Session(DateTime day)
+        {
+            return new[]
+            {
+                new TradeBar { Time = day.AddHours(10), Open = 100m, High = 102m, Low = 99m, Close = 101m, Volume = 100 },
+                new TradeBar { Time = day.AddHours(11), Open = 101m, High = 104m, Low = 100m, Close = 103m, Volume = 300 },
+                new TradeBar { Time = day.AddHours(12), Open = 103m, High = 106m, Low = 102m, Close = 105m, Volume = 200 }
+            };
+        }
+
+        [Test]
+        public void ResetsProperly()
+        {
+            var vwap = new IntradayVwap("VWAP");
+            foreach (var bar in Session(new DateTime(2024, 1, 2)))
+            {
+                vwap.Update(bar);
+            }
+
+            Assert.IsTrue(vwap.IsReady);
+
+            vwap.Reset();
+
+            TestHelper.AssertIndicatorIsInDefaultState(vwap);
+        }
+
+        [Test]
+        public void ProducesTheSameValuesAfterReset()
+        {
+            var vwap = new IntradayVwap("VWAP");
+            var bars = Session(new DateTime(2024, 1, 2));
+
+            var expected = new List<decimal>();
+            foreach (var bar in bars)
+            {
+                vwap.Update(bar);
+                expected.Add(vwap.Current.Value);
+            }
+
+            vwap.Reset();
+
+            for (var i = 0; i < bars.Length; i++)
+            {
+                vwap.Update(bars[i]);
+                Assert.AreEqual(expected[i], vwap.Current.Value);
+            }
+        }
+
+        [Test]
+        public void CarriesNoVolumeAcrossAResetWithinTheSameSession()
+        {
+            var day = new DateTime(2024, 1, 2);
+            var bars = Session(day);
+
+            var vwap = new IntradayVwap("VWAP");
+            foreach (var bar in bars)
+            {
+                vwap.Update(bar);
+            }
+            vwap.Reset();
+            vwap.Update(bars[0]);
+
+            var fresh = new IntradayVwap("VWAP");
+            fresh.Update(bars[0]);
+
+            Assert.AreEqual(fresh.Current.Value, vwap.Current.Value);
+        }
+    }
+}


### PR DESCRIPTION
#### Description

IntradayVwap never overrode Reset(), so _sumOfVolume, _sumOfPriceTimesVolume and _lastDate survived it. Since IsReady is _sumOfVolume > 0, the indicator reported itself ready straight after a reset, and a replay inside the same session blended the previous volume into the average.

Closes #9703

#### Related Issue

#9703

#### Motivation and Context

TestHelper.AssertIndicatorIsInDefaultState asserts IsFalse(indicator.IsReady) and CommonIndicatorTests.ResetsProperly calls it for every indicator that has a test class. IntradayVwap had none, so the check that would have caught this has never run against it.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

Added Tests/Indicators/IntradayVwapTests.cs with three tests: the default state after a reset, a replay reproducing the same values, and a same-session reset matching a fresh instance. All three fail with the override removed and pass with it.
