### PR TITLE
Report NewHighsNewLows as not ready while no asset is tracked

### DIFF
--- a/Indicators/NewHighsNewLows.cs
+++ b/Indicators/NewHighsNewLows.cs
@@ -233,9 +233,12 @@ namespace QuantConnect.Indicators
 
         private bool HasSufficientPreviousDataForComputation()
         {
-            return _trackedAssets.All(asset =>
-                asset.RollingPreviousHigh.IsReady
-                && asset.RollingPreviousLow.IsReady);
+            // All() holds over an empty set, so without this the indicator reports itself
+            // ready before any asset is tracked
+            return _trackedAssets.Any()
+                && _trackedAssets.All(asset =>
+                    asset.RollingPreviousHigh.IsReady
+                    && asset.RollingPreviousLow.IsReady);
         }
 
         private void UpdatePreviousValues(TrackedAsset asset, IBaseDataBar bar)

--- a/Tests/Indicators/NewHighsNewLowsTestsBase.cs
+++ b/Tests/Indicators/NewHighsNewLowsTestsBase.cs
@@ -162,5 +162,24 @@ namespace QuantConnect.Tests.Indicators
                 ibmRenkoConsolidator.Dispose();
             }
         }
+
+        [Test]
+        public void IsNotReadyWithoutTrackedAssets()
+        {
+            var indicator = CreateNewHighsNewLowsIndicator();
+
+            Assert.IsFalse(indicator.IsReady);
+        }
+
+        [Test]
+        public void IsNotReadyOnceTheLastTrackedAssetIsRemoved()
+        {
+            var indicator = CreateNewHighsNewLowsIndicator();
+            indicator.Add(Symbols.AAPL);
+            indicator.Remove(Symbols.AAPL);
+
+            Assert.IsFalse(indicator.IsReady);
+        }
+
     }
 }


### PR DESCRIPTION
#### Description

HasSufficientPreviousDataForComputation is an All over the tracked assets, and All holds over an empty set. IsReady is that predicate, so a NewHighsNewLows with nothing tracked reported itself ready with zero samples, and so did one whose last asset had been removed. Adding Any() in front settles both.

Closes #9704

#### Related Issue

#9704

#### Motivation and Context

Add and Remove are public, so a universe that empties reaches the state. ValidateAndComputeNextValue gates on the same predicate, and the HasMissingCurrentPeriodValue check three lines above it is an Any, false on an empty set, so nothing else stopped the call either. NewHighsNewLowsVolume inherits the same base.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

Two tests on NewHighsNewLowsTestsBase, so they run for all three derived classes: a fresh indicator and one whose last asset was removed. Six fail without the guard. The NewHighsNewLows tests are 48 green with it.
