### PR TITLE
Report the extra bar three candlestick patterns wait for

### DIFF
--- a/Indicators/CandlestickPatterns/AbandonedBaby.cs
+++ b/Indicators/CandlestickPatterns/AbandonedBaby.cs
@@ -91,6 +91,11 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         }
 
         /// <summary>
+        /// Required period, in data points, for the indicator to be ready and fully initialized.
+        /// </summary>
+        public override int WarmUpPeriod => Period + 1;
+
+        /// <summary>
         /// Computes the next value of this indicator from the given state
         /// </summary>
         /// <param name="window">The window of data held in this indicator</param>

--- a/Indicators/CandlestickPatterns/MatHold.cs
+++ b/Indicators/CandlestickPatterns/MatHold.cs
@@ -86,6 +86,11 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         }
 
         /// <summary>
+        /// Required period, in data points, for the indicator to be ready and fully initialized.
+        /// </summary>
+        public override int WarmUpPeriod => Period + 1;
+
+        /// <summary>
         /// Computes the next value of this indicator from the given state
         /// </summary>
         /// <param name="window">The window of data held in this indicator</param>

--- a/Indicators/CandlestickPatterns/RiseFallThreeMethods.cs
+++ b/Indicators/CandlestickPatterns/RiseFallThreeMethods.cs
@@ -68,6 +68,11 @@ namespace QuantConnect.Indicators.CandlestickPatterns
         }
 
         /// <summary>
+        /// Required period, in data points, for the indicator to be ready and fully initialized.
+        /// </summary>
+        public override int WarmUpPeriod => Period + 1;
+
+        /// <summary>
         /// Computes the next value of this indicator from the given state
         /// </summary>
         /// <param name="window">The window of data held in this indicator</param>

--- a/Tests/Indicators/CandlestickPatterns/CandlestickPatternTests.cs
+++ b/Tests/Indicators/CandlestickPatterns/CandlestickPatternTests.cs
@@ -153,6 +153,21 @@ namespace QuantConnect.Tests.Indicators.CandlestickPatterns
             TestHelper.TestIndicatorReset(indicator, testFileName);
         }
 
+        [Test, TestCaseSource(nameof(PatternTestParameters))]
+        public void WarmsUpProperly(CandlestickPattern indicator, string columnName, string testFileName)
+        {
+            var period = indicator.WarmUpPeriod;
+            var startDate = new DateTime(2019, 1, 1);
+
+            for (var i = 0; i < period; i++)
+            {
+                indicator.Update(new TradeBar(startDate.AddDays(i), Symbols.SPY, 100m + i, 105m + i, 95m + i, 100m + i, 100m, Time.OneDay));
+                Assert.AreEqual(i == period - 1, indicator.IsReady);
+            }
+
+            Assert.AreEqual(period, indicator.Samples);
+        }
+
         private static Action<IndicatorBase<IBaseDataBar>, double> Assertion
         {
             get

--- a/Tests/Indicators/CandlestickPatterns/CandlestickPatternTests.cs
+++ b/Tests/Indicators/CandlestickPatterns/CandlestickPatternTests.cs
@@ -156,6 +156,9 @@ namespace QuantConnect.Tests.Indicators.CandlestickPatterns
         [Test, TestCaseSource(nameof(PatternTestParameters))]
         public void WarmsUpProperly(CandlestickPattern indicator, string columnName, string testFileName)
         {
+            // the sample count below only means anything from a known starting point
+            indicator.Reset();
+
             var period = indicator.WarmUpPeriod;
             var startDate = new DateTime(2019, 1, 1);
 


### PR DESCRIPTION
#### Description

`AbandonedBaby`, `MatHold` and `RiseFallThreeMethods` override `IsReady` to `Samples > Period` and
leave `WarmUpPeriod` at `WindowIndicator`'s `Period`, so each turns ready one bar after the count it
publishes. The override returns `Period + 1`.

#### Related Issue

Closes #9709

#### Motivation and Context

`WarmUpIndicator` feeds exactly `WarmUpPeriod` bars and hands back an indicator the caller treats as
ready. For these three it is not, and the first value read after warming up is 0.

Changing the comparison instead would move what the patterns report. Accumulation runs under
`if (!IsReady)`, so readiness a bar earlier drops one term from every average and the TA-Lib fixture
values move with it. `Period + 1` changes no value anywhere. If you would rather these three matched
the other 58 and used `>=`, that is a larger change and I am happy to do it that way instead.

The other 58 patterns already agree with their own `WarmUpPeriod`. `EveningDojiStar` and
`MorningDojiStar` carry AbandonedBaby's three candle settings and declare `... + 2 + 1` against its
`... + 2`; `Breakaway` and `LadderBottom` have MatHold's exact period expression with `>=`.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

Added `WarmsUpProperly` to `CandlestickPatternTests`, matching `CommonIndicatorTests.WarmsUpProperly`
and using the same `PatternTestParameters` source as the three tests already there.
`CandlestickPatternTests` does not derive from `CommonIndicatorTests`, so of the four shared tests
the patterns only ever ran two, which is why this went unseen.

My local NUnit host crashes in a Python.NET finalizer before any test runs, because
`QuantConnect.pythonnet` 2.0.65 wants Python 3.11 and this machine has 3.10. So the test was
replayed from a console program linked against `QuantConnect.Indicators`, running the same loop over
the same bars: 61 patterns pass, and reverting the three overrides fails exactly AbandonedBaby,
MatHold and RiseFallThreeMethods. The same program drives and resets all 177 constructible
indicators and finds no other disagreement between `WarmUpPeriod` and `IsReady`.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
