### PR TITLE
Stop McClellanOscillator counting one shared bar twice

### DIFF
--- a/Indicators/McClellanOscillator.cs
+++ b/Indicators/McClellanOscillator.cs
@@ -50,7 +50,9 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Required period, in data points, for the indicator to be ready and fully initialized.
         /// </summary>
-        public int WarmUpPeriod => EMASlow.WarmUpPeriod + ADDifference.WarmUpPeriod;
+        /// <remarks>The two periods share a bar: EMASlow is fed by ADDifference and only
+        /// once it is ready, so ADDifference's last warm-up bar is EMASlow's first input.</remarks>
+        public int WarmUpPeriod => EMASlow.WarmUpPeriod + ADDifference.WarmUpPeriod - 1;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="McClellanOscillator"/> class

--- a/Tests/Indicators/McClellanOscillatorTests.cs
+++ b/Tests/Indicators/McClellanOscillatorTests.cs
@@ -58,11 +58,12 @@ namespace QuantConnect.Tests.Indicators
                 indicator.Update(new TradeBar() { Symbol = Symbols.AAPL, Close = i, Volume = 1, Time = reference.AddMinutes(i) });
                 indicator.Update(new TradeBar() { Symbol = Symbols.MSFT, Close = i, Volume = 1, Time = reference.AddMinutes(i) });
                 indicator.Update(new TradeBar() { Symbol = Symbols.GOOG, Close = i, Volume = 1, Time = reference.AddMinutes(i) });
+
+                Assert.AreEqual(i == indicator.WarmUpPeriod, indicator.IsReady);
             }
 
             Assert.AreEqual(0m, indicator.Current.Value);
             Assert.AreEqual(indicator.WarmUpPeriod * 3, indicator.Samples);
-            Assert.IsTrue(indicator.IsReady);
         }
 
         [Test]

--- a/Tests/Indicators/McClellanSummationIndexTests.cs
+++ b/Tests/Indicators/McClellanSummationIndexTests.cs
@@ -57,11 +57,12 @@ namespace QuantConnect.Tests.Indicators
                 indicator.Update(new TradeBar() { Symbol = Symbols.AAPL, Close = i, Volume = 1, Time = reference.AddMinutes(i) });
                 indicator.Update(new TradeBar() { Symbol = Symbols.MSFT, Close = i, Volume = 1, Time = reference.AddMinutes(i) });
                 indicator.Update(new TradeBar() { Symbol = Symbols.GOOG, Close = i, Volume = 1, Time = reference.AddMinutes(i) });
+
+                Assert.AreEqual(i == indicator.WarmUpPeriod, indicator.IsReady);
             }
 
             Assert.AreEqual(60m, indicator.Current.Value);
             Assert.AreEqual(indicator.WarmUpPeriod * 3, indicator.Samples);
-            Assert.IsTrue(indicator.IsReady);
         }
 
         [Test]


### PR DESCRIPTION
#### Description

`McClellanOscillator.WarmUpPeriod` adds `EMASlow.WarmUpPeriod` and `ADDifference.WarmUpPeriod`,
and those two overlap by one bar, so it reports 41 while the indicator is ready on 40.
`McClellanSummationIndex` delegates to it and reports the same. Subtracting the shared bar
fixes both.

#### Related Issue

Closes #9711

#### Motivation and Context

`EMASlow` is `ADDifference.EMA(slowPeriod)` and `IndicatorExtensions.EMA` passes
`waitForFirstToReady = true`, so `EMASlow` takes its first input on the bar `ADDifference`
becomes ready rather than the one after. Adding the periods counts that bar in both.

Nothing the indicator reports moves. At 40 bars the oscillator is 0 and the summation index
is 60, the same as at 41, and `Samples` is `WarmUpPeriod * 3` either way, so the two value
assertions in those tests hold unchanged.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

Both fixtures override `WarmsUpProperly` and assert `IsTrue(IsReady)` after `WarmUpPeriod`
bars without asserting it was false before, which is why an early ready passed. Each now
asserts readiness on every bar, the shape `CommonIndicatorTests.WarmsUpProperly` uses.

Four inherited tests also read `WarmUpPeriod`. `TracksPreviousState`, `WorksWithLowValues`
and `IndicatorShouldHaveSymbolAfterUpdates` use it only as a loop bound of `2 * period`, and
`WarmUpIndicatorProducesConsistentResults` feeds exactly `period` bars per symbol and then
asserts `IsReady`, which this change makes tight rather than slack. Neither fixture overrides
any of the four.

My local NUnit host crashes in a Python.NET finalizer before any test runs, because
`QuantConnect.pythonnet` 2.0.65 wants Python 3.11 and this machine has 3.10, the same
limitation I noted on #9694. So this was measured from a console program linked against
`QuantConnect.Indicators`, feeding three symbols per bar as the fixtures do: ready on bar 40
against a reported 41, and reverting the change puts it back. The same program drives and
resets all 190 constructible indicators and finds no other disagreement between
`WarmUpPeriod` and `IsReady`.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
