### PR TITLE
Align the AR and MA rows in AutoRegressiveIntegratedMovingAverage

### DIFF
--- a/Indicators/AutoRegressiveIntegratedMovingAverage.cs
+++ b/Indicators/AutoRegressiveIntegratedMovingAverage.cs
@@ -262,10 +262,16 @@ namespace QuantConnect.Indicators
         {
             var appendedData = new List<double[]>();
             var laggedErrors = LaggedSeries(_maOrder, _residuals.ToArray());
-            for (var i = 0; i < laggedErrors.Length; i++)
+            // lags[i] is the AR row for time i + _arOrder and laggedErrors[j] the MA row for
+            // time j + _maOrder, so the two are only the same row when the orders match.
+            // Walking laggedErrors and indexing lags by the same counter ran off the end of
+            // lags whenever _arOrder > _maOrder, and paired rows from different times when
+            // it was the other way round.
+            var offset = Math.Max(_arOrder, _maOrder);
+            for (var t = offset; t < data.Length; t++)
             {
-                var doubles = lags[i].ToList();
-                doubles.AddRange(laggedErrors[i]);
+                var doubles = lags[t - _arOrder].ToList();
+                doubles.AddRange(laggedErrors[t - _maOrder]);
                 appendedData.Add(doubles.ToArray());
             }
 
@@ -274,7 +280,7 @@ namespace QuantConnect.Indicators
             {
                 try
                 {
-                    maFits = Fit.MultiDim(appendedData.ToArray(), data.Skip(_maOrder).ToArray(),
+                    maFits = Fit.MultiDim(appendedData.ToArray(), data.Skip(offset).ToArray(),
                 method: DirectRegressionMethod.NormalEquations, intercept: _intercept);
                 }
                 catch (Exception ex)
@@ -293,22 +299,24 @@ namespace QuantConnect.Indicators
                     // It's worth saying that if intercept flag is set to true, the number of columns of the initial
                     // matrix (appendedData) is increased in one. For more information, please see the implementation
                     // of Fit.MultiDim() method (Ctrl + right click)
-                    var size = appendedData.ToArray()[0].Length + (_intercept ? 1 : 0);
+                    // Each row is _arOrder AR lags followed by _maOrder lagged errors, which
+                    // is the width even when there are no rows at all to read it off.
+                    var size = _arOrder + _maOrder + (_intercept ? 1 : 0);
                     maFits = new double[size];
                 }
             }
             else
             {
-                maFits = Fit.MultiDim(appendedData.ToArray(), data.Skip(_maOrder).ToArray(),
+                maFits = Fit.MultiDim(appendedData.ToArray(), data.Skip(offset).ToArray(),
                 method: DirectRegressionMethod.NormalEquations, intercept: _intercept);
             }
 
-            for (var i = _maOrder; i < data.Length; i++) // Calculate the error assoc. with model.
+            for (var i = offset; i < data.Length; i++) // Calculate the error assoc. with model.
             {
                 var paramVector = _intercept
                     ? Vector.Build.Dense(maFits.Skip(1).ToArray())
                     : Vector.Build.Dense(maFits);
-                var residual = data[i] - Vector.Build.Dense(appendedData[i - _maOrder]).DotProduct(paramVector);
+                var residual = data[i] - Vector.Build.Dense(appendedData[i - offset]).DotProduct(paramVector);
                 errorMa += Math.Pow(residual, 2);
             }
 
@@ -359,7 +367,9 @@ namespace QuantConnect.Indicators
                     // aforementioned matrix and b is the data. Thus, the size of the response x is n
                     //
                     // For more information, please see the implementation of Fit.MultiDim() method (Ctrl + right click)
-                    var size = lags.ToArray()[0].Length;
+                    // Each row holds _arOrder lags, and reading that width off row zero threw
+                    // when the fit had failed because there were no rows at all.
+                    var size = _arOrder;
                     arFits = new double[size];
                 }
             }

--- a/Tests/Indicators/AutoregressiveIntegratedMovingAverageTests.cs
+++ b/Tests/Indicators/AutoregressiveIntegratedMovingAverageTests.cs
@@ -53,6 +53,22 @@ namespace QuantConnect.Tests.Indicators
                 (ind, expected) => Assert.AreEqual(expected, (double) ARIMA.Current.Value, 10d));
         }
 
+        [TestCase(2, 0, 1)]
+        [TestCase(3, 1, 1)]
+        [TestCase(4, 0, 2)]
+        public void AcceptsAnAutoRegressiveOrderAboveTheMovingAverageOrder(int arOrder, int diffOrder, int maOrder)
+        {
+            var arima = new AutoRegressiveIntegratedMovingAverage(arOrder, diffOrder, maOrder, 50, true);
+            var reference = new DateTime(2020, 1, 1);
+
+            for (var i = 0; i < 60; i++)
+            {
+                arima.Update(reference.AddDays(i), 100m + (decimal)Math.Sin(i / 3d) * 5m);
+            }
+
+            Assert.IsTrue(arima.IsReady);
+        }
+
         [Test]
         public void PredictionErrorAgainstExternalData()
         {


### PR DESCRIPTION
#### Description

`MovingAverageStep` walked the lagged errors and indexed the AR lags with the same counter,
which runs off the end of `lags` whenever `arOrder > maOrder`. It now walks time and indexes
each array by its own offset.

#### Related Issue

Closes #9712

#### Motivation and Context

`ARIMA(2, 0, 1)` throws at any period. At period 50, 24 of the 80 order sets the constructor
accepts throw.

`lags[i]` is the row for time `i + _arOrder` and `laggedErrors[j]` the row for `j + _maOrder`,
so the counters agree only when the orders do.

The other direction does not throw, and that is the part worth looking hardest at. It pairs
an AR row from one bar with error terms from another, so the model gets fitted on rows that
never coexisted, and the fitted values move once they line up: `ARIMA(1, 0, 2, 50)` over a
deterministic series ends at 100.103983 before this change and 101.581063 after.

Two `catch` blocks added for #8039 also read their row width off row zero, so a fit that
failed for having no rows threw out of the handler meant to absorb it. Both widths follow
from the orders.

177 of 456 accepted order sets still throw at periods of 8 or less, so the issue is not fully
closed. `period < Math.Max(arOrder, maOrder)` is weaker than what the fit needs, by up to six
bars in the range I measured, and tightening it is a separate call.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

`AcceptsAnAutoRegressiveOrderAboveTheMovingAverageOrder` covers `(2, 0, 1)`, `(3, 1, 1)` and
`(4, 0, 2)`. All three throw on master. A fourth case with `maOrder > arOrder` came out of the
draft because it passes there, so it would have been a test that never fails.

Every test in the file uses `ARIMA(1, 0, 1, 50)`, the diagonal where the orders match and the
old bound is accidentally right, so the change is a no-op there. That configuration sums to
7090.1814358551 over 120 points of a deterministic series and ends at 103.9912907073, both
before and after.

My local NUnit host crashes in a Python.NET finalizer before any test runs, because
`QuantConnect.pythonnet` 2.0.65 wants Python 3.11 and this machine has 3.10, the same
limitation I noted on #9694. The figures above come from a console program linked against
`QuantConnect.Indicators`, which dumps the outcome of all 640 order-set and period
combinations on master and on this branch and diffs them: 116 newly work, 0 newly throw.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
