### PR TITLE
Handle null custom data source during live refresh

### DIFF
--- a/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactory.cs
+++ b/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactory.cs
@@ -81,6 +81,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators.Factories
                 lastSourceRefreshTime = utcNow;
                 var localDate = _dateAdjustment?.Invoke(utcNow.ConvertFromUtc(config.ExchangeTimeZone).Date) ?? utcNow.ConvertFromUtc(config.ExchangeTimeZone).Date;
                 var source = sourceFactory.GetSource(config, localDate, true);
+                if (source == null)
+                {
+                    return Enumerable.Empty<BaseData>().GetEnumerator();
+                }
 
                 // fetch the new source and enumerate the data source reader
                 var enumerator = EnumerateDataSourceReader(config, dataProvider, frontier, source, localDate, sourceFactory);

--- a/Tests/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactoryTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/Factories/LiveCustomDataSubscriptionEnumeratorFactoryTests.cs
@@ -467,6 +467,25 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
             }
         }
 
+        [Test]
+        public void NullSourceYieldsNoData()
+        {
+            var referenceLocal = new DateTime(2017, 10, 12);
+            var referenceUtc = referenceLocal.ConvertToUtc(TimeZones.NewYork);
+            var timeProvider = new ManualTimeProvider(referenceUtc);
+            var dataSourceReader = new Mock<ISubscriptionDataSourceReader>();
+            var config = new SubscriptionDataConfig(typeof(NullSourceData), Symbols.SPY, Resolution.Second,
+                TimeZones.NewYork, TimeZones.NewYork, false, false, false);
+            var request = GetSubscriptionRequest(config, referenceUtc.AddSeconds(-1), referenceUtc.AddDays(1));
+            var factory = new TestableLiveCustomDataSubscriptionEnumeratorFactory(timeProvider, dataSourceReader.Object);
+
+            using var enumerator = factory.CreateEnumerator(request, null);
+
+            Assert.IsTrue(enumerator.MoveNext());
+            Assert.IsNull(enumerator.Current);
+            dataSourceReader.Verify(reader => reader.Read(It.IsAny<SubscriptionDataSource>()), Times.Never);
+        }
+
         [TestCase(10)]
         [TestCase(60)]
         [TestCase(0)]
@@ -586,6 +605,14 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators.Factories
             public override SubscriptionDataSource GetSource(SubscriptionDataConfig config, DateTime date, bool isLiveMode)
             {
                 return new SubscriptionDataSource("local.file.source", SubscriptionTransportMedium.LocalFile);
+            }
+        }
+
+        class NullSourceData : BaseData
+        {
+            public override SubscriptionDataSource GetSource(SubscriptionDataConfig config, DateTime date, bool isLiveMode)
+            {
+                return null;
             }
         }
 


### PR DESCRIPTION
#### Description

Handle a null source returned by live custom data during an enumerator refresh.

`LiveCustomDataSubscriptionEnumeratorFactory` currently passes the result of `GetSource()` into a deferred reader enumerator and then immediately dereferences it in `SourceRequiresFastForward()`. When `GetSource()` returns null, the exception escapes through `RefreshEnumerator.MoveNext()` and is repeatedly logged by the live data feed.

This change treats a null source as no data for the current refresh cycle. The refresh timestamp is still updated, so the existing retry cadence is preserved, and the data-source reader is not invoked until a valid source is available.

#### Related Issue

Closes #9715.

#### Motivation and Context

Custom data source discovery can legitimately yield no source for a given live refresh. Other data-feed paths tolerate this as an empty cycle; this factory should not turn it into an unhandled `NullReferenceException`.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

Added `NullSourceYieldsNoData` to `LiveCustomDataSubscriptionEnumeratorFactoryTests`. The test uses a `BaseData` implementation whose `GetSource()` returns null and verifies that:

- advancing the refresh enumerator does not throw;
- it yields no data for the cycle;
- the subscription data-source reader is never called.

The test failed with the reported `NullReferenceException` before the fix and passes after it. The full factory fixture passes: 9 tests, 0 failures.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [x] My code follows the code style of this project.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] The focused factory test fixture passes.
- [x] My branch follows the `bug-<issue#>-<description>` naming convention.
