### PR TITLE
Normalize result server statistics and report them for live

### DIFF
--- a/Common/Api/LiveAlgorithmResults.cs
+++ b/Common/Api/LiveAlgorithmResults.cs
@@ -93,6 +93,12 @@ namespace QuantConnect.Api
         public IDictionary<string, string> RuntimeStatistics { get; set; }
 
         /// <summary>
+        /// Server status information, including CPU/RAM usage, ect...
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public IDictionary<string, string> ServerStatistics { get; set; }
+
+        /// <summary>
         /// Charts updates for the live algorithm since the last result packet
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]

--- a/Common/Api/LiveAlgorithmResultsJsonConverter.cs
+++ b/Common/Api/LiveAlgorithmResultsJsonConverter.cs
@@ -125,8 +125,25 @@ namespace QuantConnect.Api
 
             liveAlgoResults.Charts = chartDictionary;
             liveAlgoResults.Files = projectFiles;
+            liveAlgoResults.RuntimeStatistics = DeserializeStatistics(jObject, "runtimeStatistics", "RuntimeStatistics");
+            liveAlgoResults.ServerStatistics = DeserializeStatistics(jObject, "serverStatistics", "ServerStatistics");
 
             return liveAlgoResults;
+        }
+
+        /// <summary>
+        /// Deserializes a statistics dictionary, if the given json holds one. Older deployments were
+        /// run before some of them were reported, so they are all optional
+        /// </summary>
+        private static IDictionary<string, string> DeserializeStatistics(JObject jObject, string name, string alternativeName)
+        {
+            var statistics = jObject[name] ?? jObject[alternativeName];
+            if (statistics == null || statistics.Type != JTokenType.Object)
+            {
+                return null;
+            }
+
+            return statistics.ToObject<Dictionary<string, string>>();
         }
     }
 }

--- a/Common/Packets/BacktestResultParameters.cs
+++ b/Common/Packets/BacktestResultParameters.cs
@@ -44,8 +44,10 @@ namespace QuantConnect.Packets
             AlgorithmPerformance totalPerformance = null,
             AlgorithmConfiguration algorithmConfiguration = null,
             IDictionary<string, string> state = null,
-            IReadOnlyList<Analysis> analysisResult = null)
-            : base(charts, orders, profitLoss, statistics, runtimeStatistics, orderEvents, totalPerformance, algorithmConfiguration, state, analysisResult)
+            IReadOnlyList<Analysis> analysisResult = null,
+            IDictionary<string, string> serverStatistics = null)
+            : base(charts, orders, profitLoss, statistics, runtimeStatistics, orderEvents, totalPerformance, algorithmConfiguration, state, analysisResult,
+                serverStatistics)
         {
             RollingWindow = rollingWindow;
         }

--- a/Common/Packets/BaseResultParameters.cs
+++ b/Common/Packets/BaseResultParameters.cs
@@ -62,6 +62,11 @@ namespace QuantConnect.Packets
         public IDictionary<string, string> State { get; set; }
 
         /// <summary>
+        /// Server status information, including CPU/RAM usage, ect...
+        /// </summary>
+        public IDictionary<string, string> ServerStatistics { get; set; }
+
+        /// <summary>
         /// The algorithm's configuration required for report generation
         /// </summary>
         public AlgorithmConfiguration AlgorithmConfiguration { get; set; }
@@ -88,7 +93,8 @@ namespace QuantConnect.Packets
             AlgorithmPerformance totalPerformance = null,
             AlgorithmConfiguration algorithmConfiguration = null,
             IDictionary<string, string> state = null,
-            IReadOnlyList<Analysis> analysisResult = null)
+            IReadOnlyList<Analysis> analysisResult = null,
+            IDictionary<string, string> serverStatistics = null)
         {
             Charts = charts;
             Orders = orders;
@@ -100,6 +106,7 @@ namespace QuantConnect.Packets
             State = state;
             TotalPerformance = totalPerformance;
             Analysis = analysisResult;
+            ServerStatistics = serverStatistics;
         }
     }
 }

--- a/Common/Packets/LiveResultParameters.cs
+++ b/Common/Packets/LiveResultParameters.cs
@@ -38,11 +38,6 @@ namespace QuantConnect.Packets
         public CashBook CashBook { get; set; }
 
         /// <summary>
-        /// Server status information, including CPU/RAM usage, ect...
-        /// </summary>
-        public IDictionary<string, string> ServerStatistics { get; set; }
-
-        /// <summary>
         /// Creates a new instance
         /// </summary>
         public LiveResultParameters(IDictionary<string, Chart> charts,
@@ -58,11 +53,11 @@ namespace QuantConnect.Packets
             AlgorithmConfiguration algorithmConfiguration = null,
             IDictionary<string, string> state = null,
             IReadOnlyList<Analysis> analysisResult = null)
-            : base(charts, orders, profitLoss, statistics, runtimeStatistics, orderEvents, totalPerformance, algorithmConfiguration, state, analysisResult)
+            : base(charts, orders, profitLoss, statistics, runtimeStatistics, orderEvents, totalPerformance, algorithmConfiguration, state, analysisResult,
+                serverStatistics ?? OS.GetServerStatistics())
         {
             Holdings = holdings;
             CashBook = cashBook;
-            ServerStatistics = serverStatistics ?? OS.GetServerStatistics();
         }
     }
 }

--- a/Common/Result.cs
+++ b/Common/Result.cs
@@ -118,6 +118,7 @@ namespace QuantConnect
             State = parameters.State;
             TotalPerformance = parameters.TotalPerformance;
             Analysis = parameters.Analysis;
+            ServerStatistics = parameters.ServerStatistics;
         }
     }
 }

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -232,10 +232,8 @@ namespace QuantConnect.Lean.Engine.Results
                         runtimeStatistics,
                         new Dictionary<string, AlgorithmPerformance>(),
                         // we store the last 100 order events, the final packet will contain the full list
-                        TransactionHandler.OrderEvents.Reverse().Take(100).ToList(), state: GetAlgorithmState()))
-                    {
-                        ServerStatistics = serverStatistics
-                    };
+                        TransactionHandler.OrderEvents.Reverse().Take(100).ToList(), state: GetAlgorithmState(),
+                        serverStatistics: serverStatistics));
 
                     if (RunResultsAnalysis)
                     {
@@ -347,10 +345,8 @@ namespace QuantConnect.Lean.Engine.Results
                             result.Results.TotalPerformance,
                             result.Results.AlgorithmConfiguration,
                             result.Results.State,
-                            result.Results.Analysis))
-                        {
-                            ServerStatistics = result.Results.ServerStatistics
-                        };
+                            result.Results.Analysis,
+                            result.Results.ServerStatistics));
 
                         if (result.Results.Charts.TryGetValue(PortfolioMarginKey, out var marginChart))
                         {

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -828,6 +828,7 @@ namespace QuantConnect.Lean.Engine.Results
             {
                 var endTime = DateTime.UtcNow;
                 var endState = GetAlgorithmState(endTime);
+                var serverStatistics = GetServerStatistics(endTime);
                 LiveResultPacket result;
                 // could happen if algorithm failed to init
                 if (Algorithm != null)
@@ -848,17 +849,17 @@ namespace QuantConnect.Lean.Engine.Results
                     var statisticsResults = GenerateStatisticsResults(charts, profitLoss);
                     var runtime = GetAlgorithmRuntimeStatistics(statisticsResults.Summary);
 
-                    StoreStatusFile(runtime, holdings, charts, endState, profitLoss, statistics: statisticsResults);
+                    StoreStatusFile(runtime, holdings, charts, endState, profitLoss, serverStatistics, statisticsResults);
 
                     //Create a packet:
                     result = new LiveResultPacket(_job,
                         new LiveResult(new LiveResultParameters(charts, orders, profitLoss, new Dictionary<string, Holding>(),
-                            Algorithm.Portfolio.CashBook, statisticsResults.Summary, runtime, GetOrderEventsToStore(),
+                            Algorithm.Portfolio.CashBook, statisticsResults.Summary, runtime, GetOrderEventsToStore(), serverStatistics: serverStatistics,
                             algorithmConfiguration: AlgorithmConfiguration.Create(Algorithm, null), state: endState, totalPerformance: statisticsResults.TotalPerformance)));
                 }
                 else
                 {
-                    StoreStatusFile(new(), new(), new(), endState, new());
+                    StoreStatusFile(new(), new(), new(), endState, new(), serverStatistics);
 
                     result = LiveResultPacket.CreateEmpty(_job);
                     result.Results.State = endState;

--- a/Tests/Engine/Results/LiveTradingResultHandlerTests.cs
+++ b/Tests/Engine/Results/LiveTradingResultHandlerTests.cs
@@ -445,6 +445,54 @@ namespace QuantConnect.Tests.Engine.Results
             }
         }
 
+        [Test]
+        public void StoredResultsCarryServerStatistics()
+        {
+            using var api = new Api.Api();
+            using var messaging = new QuantConnect.Messaging.Messaging();
+            var deployId = "TestDeployId";
+            var resultHandler = new TestableStoredResultsHandler();
+            resultHandler.Initialize(new(new LiveNodePacket { DeployId = deployId }, messaging, api, new BacktestingTransactionHandler(), null));
+
+            var algorithm = new AlgorithmStub();
+            algorithm.SetFinishedWarmingUp();
+            resultHandler.SetAlgorithm(algorithm, 100000);
+
+            // the final result is stored on exit
+            resultHandler.Exit();
+
+            // the status file and the minute resolution results are the ones the API reads the statistics from
+            foreach (var name in new[] { $"{deployId}.json", $"{deployId}-{DateTime.UtcNow:yyyy-MM-dd}_minute.json" })
+            {
+                var stored = resultHandler.StoredResults.Where(pair => pair.Key.EndsWith(name, StringComparison.InvariantCulture)).ToList();
+                Assert.IsNotEmpty(stored, $"No result was stored for '{name}'");
+
+                foreach (var result in stored)
+                {
+                    Assert.IsNotNull(result.Value.ServerStatistics, $"'{result.Key}' is missing the server statistics");
+                    Assert.IsTrue(result.Value.ServerStatistics.ContainsKey("Hostname"));
+                }
+            }
+        }
+
+        private class TestableStoredResultsHandler : LiveTradingResultHandler
+        {
+            public List<KeyValuePair<string, Result>> StoredResults { get; } = new();
+
+            public override void SaveResults(string name, Result result)
+            {
+                lock (StoredResults)
+                {
+                    StoredResults.Add(new(name, result));
+                }
+            }
+
+            public override string SaveLogs(string id, List<LogEntry> logs)
+            {
+                return string.Empty;
+            }
+        }
+
         private class TestableLiveTradingResultHandler : LiveTradingResultHandler
         {
             public decimal ExposedStartingPortfolioValue => StartingPortfolioValue;


### PR DESCRIPTION
#### Description

Follow up to #9719, which exposed `serverStatistics` on the backtest read DTO. This normalizes where the field lives and makes live report it too.

`ServerStatistics` was declared on the base `Result`, but its constructor parameter only existed on `LiveResultParameters` — and nothing ever read it. Neither `Result(BaseResultParameters)` nor `LiveResult(LiveResultParameters)` copied it across, so every live result built through the parameters class silently dropped it. The only live path that carried it was `SplitPackets`, which bypasses the parameters class with an object initializer. That is also why the backtest side needed an object initializer on top of the constructor.

Changes:

- `ServerStatistics` moves up to `BaseResultParameters` and is assigned in the `Result` constructor, so backtest and live share one path. `BacktestResultParameters` gains the same optional parameter, and the two object initializer workarounds in `BacktestingResultHandler` are dropped.
- `LiveTradingResultHandler.SendFinalResult` now reports the server statistics to the status file and the final packet, matching `BacktestingResultHandler`. Without this the `?? OS.GetServerStatistics()` fallback would land a bare OS snapshot missing `Hostname`, `Up Time` and `Total RAM (MB)`.
- `LiveAlgorithmResults` exposes `ServerStatistics`, optional since older deployments ran before Lean stored it. It is wired through `LiveAlgorithmResultsJsonConverter`, which builds the response by hand and was dropping `RuntimeStatistics` for the same reason, so both are populated now.

Net effect: the live status file and the minute/10 minute result files now carry the server statistics, which is where the cloud API reads a running deployment's statistics from.

#### Related Issue

Follow up to #9719.

#### Motivation and Context

The backtest read endpoint reports CPU/RAM/uptime for a completed backtest, but there was no equivalent for a running deployment even though the live result handler was already computing the same dictionary every update pass and passing it along — it just never reached the stored results. Having the field on one base class instead of two subclasses also removes the need for callers to remember an object initializer.

#### Requires Documentation Change

The `live/read` response gains an optional `serverStatistics` object, mirroring the `backtests/read` one added in #9719.

#### How Has This Been Tested?

Added `LiveTradingResultHandlerTests.StoredResultsCarryServerStatistics`, which drives the handler through exit and asserts the stored status file and minute result both carry the statistics, including the `Hostname` key that only `BaseResultsHandler.GetServerStatistics` adds. It fails on master.

Ran locally on Windows, .NET 10, Release:

- `LiveTradingResultHandlerTests` — 16 passed
- `BacktestingResultHandlerTests`, `BaseResultsHandlerTests`, `ResultDeserializationTests`, `PacketTests` — 56 passed
- Full solution builds with no new warnings

The remaining regression suite is left to CI.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. <!--- see the scope noted above -->
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>` <!--- named to pair with the backtest branch from #9719 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
