### PR TITLE
Parallelize live warmup enumeration

### DIFF
--- a/Engine/DataFeeds/LiveTradingDataFeed.cs
+++ b/Engine/DataFeeds/LiveTradingDataFeed.cs
@@ -456,6 +456,10 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     // don't let future data past. We let null pass because that's letting the next enumerator know we've ended because we always return true in live
                     synchronizedWarmupEnumerator = new FilterEnumerator<BaseData>(synchronizedWarmupEnumerator, data => data == null || data.EndTime <= warmupRequest.EndTimeLocal);
 
+                    // schedule the warmup enumeration on a worker: it performs blocking IO, history requests, disk and custom data sources,
+                    // this allows the subscriptions to warm up concurrently instead of sequentially driven by the synchronizer thread
+                    synchronizedWarmupEnumerator = SubscriptionUtils.ScheduleEnumerator(warmupRequest.Configuration.Symbol, synchronizedWarmupEnumerator);
+
                     // the order here is important, concat enumerator will keep the last enumerator given and dispose of the rest
                     liveEnumerator = new ConcatEnumerator(true, synchronizedWarmupEnumerator, liveEnumerator);
                 }

--- a/Engine/DataFeeds/SubscriptionUtils.cs
+++ b/Engine/DataFeeds/SubscriptionUtils.cs
@@ -88,6 +88,74 @@ namespace QuantConnect.Lean.Engine.DataFeeds
             enablePriceScale = enablePriceScale && config.PricesShouldBeScaled();
             var lastTradableDate = DateTime.MinValue;
 
+            ScheduleEnumerator(config.Symbol, enumerator, enqueueable, data =>
+            {
+                // Use our config filter to see if we should emit this
+                // This currently catches Auxiliary data that we don't want to emit
+                if (data != null && !config.ShouldEmitData(data, request.IsUniverseSubscription))
+                {
+                    return null;
+                }
+
+                // In the event we have "Raw" configuration, we will force our subscription data
+                // to precalculate adjusted data. The data will still be emitted as raw, but
+                // if the config is changed at any point it can emit adjusted data as well
+                // See SubscriptionData.Create() and PrecalculatedSubscriptionData for more
+                var requestMode = config.DataNormalizationMode;
+                if (config.SecurityType == SecurityType.Equity)
+                {
+                    requestMode = requestMode != DataNormalizationMode.Raw ? requestMode : DataNormalizationMode.Adjusted;
+                }
+
+                var priceScaleFrontierDate = data.GetUpdatePriceScaleFrontier().Date;
+
+                // We update our price scale factor when the date changes for non fill forward bars or if we haven't initialized yet.
+                // We don't take into account auxiliary data because we don't scale it and because the underlying price data could be fill forwarded
+                if (enablePriceScale && priceScaleFrontierDate > lastTradableDate && data.DataType != MarketDataType.Auxiliary && (!data.IsFillForward || lastTradableDate == DateTime.MinValue))
+                {
+                    var factorFile = factorFileProvider.Get(request.Configuration.Symbol);
+                    lastTradableDate = priceScaleFrontierDate;
+                    request.Configuration.PriceScaleFactor = factorFile.GetPriceScale(lastTradableDate, requestMode, config.ContractDepthOffset, config.DataMappingMode);
+                }
+
+                return SubscriptionData.Create(dailyStrictEndTimeEnabled,
+                    config,
+                    exchangeHours,
+                    subscription.OffsetProvider,
+                    data,
+                    requestMode,
+                    enablePriceScale ? request.Configuration.PriceScaleFactor : null);
+            });
+
+            return subscription;
+        }
+
+        /// <summary>
+        /// Setups a worker task to enumerate the given enumerator, feeding a blocking <see cref="EnqueueableEnumerator{T}"/> which is returned.
+        /// Useful for enumerators which perform blocking IO, like the live warmup enumerators performing history requests, so that they run
+        /// concurrently on the workers instead of sequentially driven by the consuming thread, which will only block until the next data
+        /// point of each enumerator is available
+        /// </summary>
+        /// <param name="symbol">The symbol associated with this work</param>
+        /// <param name="enumerator">The data enumerator stack to enumerate</param>
+        /// <returns>A blocking enumerator providing the data</returns>
+        public static IEnumerator<BaseData> ScheduleEnumerator(Symbol symbol, IEnumerator<BaseData> enumerator)
+        {
+            var enqueueable = new EnqueueableEnumerator<BaseData>(blocking: true);
+            ScheduleEnumerator(symbol, enumerator, enqueueable, data => data, endOnNullDataPoint: true);
+            return enqueueable;
+        }
+
+        /// <summary>
+        /// Setups a worker task to enumerate the given enumerator, processing each data point and feeding the given enumerator
+        /// </summary>
+        /// <param name="endOnNullDataPoint">When true, a null data point is taken as the enumerator having ended, since in live mode
+        /// enumerators will return true with a null current value when they have no more data. Else null data points are forwarded</param>
+        /// <remarks>A null processed non null data point is skipped</remarks>
+        private static void ScheduleEnumerator<T>(Symbol symbol, IEnumerator<BaseData> enumerator, EnqueueableEnumerator<T> enqueueable,
+            Func<BaseData, T> processDataPoint, bool endOnNullDataPoint = false)
+            where T : class
+        {
             Func<int, bool> produce = (workBatchSize) =>
             {
                 try
@@ -95,7 +163,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     var count = 0;
                     while (enumerator.MoveNext())
                     {
-                        // subscription has been removed, no need to continue enumerating
+                        // the consumer has been removed, no need to continue enumerating
                         if (enqueueable.HasFinished)
                         {
                             enumerator.DisposeSafely();
@@ -103,45 +171,20 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                         }
 
                         var data = enumerator.Current;
-
-                        // Use our config filter to see if we should emit this
-                        // This currently catches Auxiliary data that we don't want to emit
-                        if (data != null && !config.ShouldEmitData(data, request.IsUniverseSubscription))
+                        if (data == null && endOnNullDataPoint)
                         {
+                            break;
+                        }
+
+                        var processedDataPoint = processDataPoint(data);
+                        if (data != null && processedDataPoint == null)
+                        {
+                            // filtered out
                             continue;
                         }
 
-                        // In the event we have "Raw" configuration, we will force our subscription data
-                        // to precalculate adjusted data. The data will still be emitted as raw, but
-                        // if the config is changed at any point it can emit adjusted data as well
-                        // See SubscriptionData.Create() and PrecalculatedSubscriptionData for more
-                        var requestMode = config.DataNormalizationMode;
-                        if (config.SecurityType == SecurityType.Equity)
-                        {
-                            requestMode = requestMode != DataNormalizationMode.Raw ? requestMode : DataNormalizationMode.Adjusted;
-                        }
-
-                        var priceScaleFrontierDate = data.GetUpdatePriceScaleFrontier().Date;
-
-                        // We update our price scale factor when the date changes for non fill forward bars or if we haven't initialized yet.
-                        // We don't take into account auxiliary data because we don't scale it and because the underlying price data could be fill forwarded
-                        if (enablePriceScale && priceScaleFrontierDate > lastTradableDate && data.DataType != MarketDataType.Auxiliary && (!data.IsFillForward || lastTradableDate == DateTime.MinValue))
-                        {
-                            var factorFile = factorFileProvider.Get(request.Configuration.Symbol);
-                            lastTradableDate = priceScaleFrontierDate;
-                            request.Configuration.PriceScaleFactor = factorFile.GetPriceScale(lastTradableDate, requestMode, config.ContractDepthOffset, config.DataMappingMode);
-                        }
-
-                        SubscriptionData subscriptionData = SubscriptionData.Create(dailyStrictEndTimeEnabled,
-                            config,
-                            exchangeHours,
-                            subscription.OffsetProvider,
-                            data,
-                            requestMode,
-                            enablePriceScale ? request.Configuration.PriceScaleFactor : null);
-
                         // drop the data into the back of the enqueueable
-                        enqueueable.Enqueue(subscriptionData);
+                        enqueueable.Enqueue(processedDataPoint);
 
                         count++;
                         // stop executing if added more data than the work batch size, we don't want to fill the ram
@@ -153,7 +196,7 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 }
                 catch (Exception exception)
                 {
-                    Log.Error(exception, $"Subscription worker task exception {request.Configuration}.");
+                    Log.Error(exception, $"Enumerator worker task exception {symbol}.");
                 }
 
                 // we made it here because MoveNext returned false or we exploded, stop the enqueueable
@@ -163,8 +206,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                 return false;
             };
 
-            WeightedWorkScheduler.Instance.QueueWork(config.Symbol, produce,
-                // if the subscription finished we return 0, so the work is prioritized and gets removed
+            WeightedWorkScheduler.Instance.QueueWork(symbol, produce,
+                // if the enumerator finished we return 0, so the work is prioritized and gets removed
                 () =>
                 {
                     if (enqueueable.HasFinished)
@@ -174,8 +217,6 @@ namespace QuantConnect.Lean.Engine.DataFeeds
                     return enqueueable.Count;
                 }
             );
-
-            return subscription;
         }
 
         /// <summary>

--- a/Engine/DataFeeds/WorkScheduling/BaseWorkScheduler.cs
+++ b/Engine/DataFeeds/WorkScheduling/BaseWorkScheduler.cs
@@ -26,7 +26,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds.WorkScheduling
         /// <summary>
         /// The quantity of workers to be used
         /// </summary>
-        public static int WorkersCount = Configuration.Config.GetInt("data-feed-workers-count", Environment.ProcessorCount);
+        /// <remarks>In live trading we default to a lower count, these workers are only used to warmup, live nodes cpu and ram are limited</remarks>
+        public static int WorkersCount = Configuration.Config.GetInt("data-feed-workers-count", Globals.LiveMode ? 2 : Environment.ProcessorCount);
 
         /// <summary>
         /// Add a new work item to the queue

--- a/Engine/DataFeeds/WorkScheduling/WeightedWorkScheduler.cs
+++ b/Engine/DataFeeds/WorkScheduling/WeightedWorkScheduler.cs
@@ -64,7 +64,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds.WorkScheduling
 
             _initializationTask = Task.Run(() =>
             {
-                MaxWorkWeight = Configuration.Config.GetInt("data-feed-max-work-weight", 400);
+                // in live trading we default to a lower weight, these workers are only used to warmup, live nodes cpu and ram are limited
+                MaxWorkWeight = Configuration.Config.GetInt("data-feed-max-work-weight", Globals.LiveMode ? 100 : 400);
                 Logging.Log.Trace($"WeightedWorkScheduler(): will use {WorkersCount} workers and MaxWorkWeight is {MaxWorkWeight}");
 
                 for (var i = 0; i < WorkersCount; i++)

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -413,6 +413,8 @@ namespace QuantConnect.Lean.Engine.Results
                 result.ProcessingTime = (endTime - StartTime).TotalSeconds;
                 result.DateFinished = DateTime.Now;
                 result.Progress = 1;
+                // set the server statistics before storing the results, so they are included in the summary and final stored result, like in live
+                result.Results.ServerStatistics = GetServerStatistics(endTime);
 
                 StoreInsights();
 
@@ -440,7 +442,6 @@ namespace QuantConnect.Lean.Engine.Results
                 //Place result into storage.
                 StoreResult(result);
 
-                result.Results.ServerStatistics = GetServerStatistics(endTime);
                 //Second, send the truncated packet:
                 MessagingHandler.Send(result);
 

--- a/Tests/Engine/DataFeeds/SubscriptionUtilsTests.cs
+++ b/Tests/Engine/DataFeeds/SubscriptionUtilsTests.cs
@@ -312,6 +312,116 @@ namespace QuantConnect.Tests.Engine.DataFeeds
             }
         }
 
+        [Test]
+        public void ScheduleEnumeratorEmitsDataInOrderAndEnds()
+        {
+            // more than a single work batch so the worker has to run multiple sprints
+            var dataPoints = new List<BaseData>();
+            for (var i = 0; i < 120; i++)
+            {
+                dataPoints.Add(new Tick(DateTime.UtcNow, Symbols.SPY, i, i));
+            }
+            var enumerator = new TestSequenceEnumerator(dataPoints);
+
+            using var result = SubscriptionUtils.ScheduleEnumerator(Symbols.SPY, enumerator);
+
+            var count = 0;
+            while (result.MoveNext())
+            {
+                Assert.IsNotNull(result.Current);
+                Assert.AreEqual(count++, result.Current.Value);
+            }
+            Assert.AreEqual(120, count);
+            Assert.IsFalse(result.MoveNext());
+            AssertDisposed(enumerator);
+        }
+
+        [Test]
+        public void ScheduleEnumeratorEndsOnNullDataPoint()
+        {
+            // in live mode enumerators return true with a null current value when they have no more data
+            var enumerator = new TestSequenceEnumerator(new List<BaseData>
+            {
+                new Tick(DateTime.UtcNow, Symbols.SPY, 1, 2),
+                null,
+                new Tick(DateTime.UtcNow, Symbols.SPY, 3, 4)
+            });
+
+            using var result = SubscriptionUtils.ScheduleEnumerator(Symbols.SPY, enumerator);
+
+            Assert.IsTrue(result.MoveNext());
+            Assert.IsNotNull(result.Current);
+            Assert.IsFalse(result.MoveNext());
+            AssertDisposed(enumerator);
+        }
+
+        [Test]
+        public void ScheduleEnumeratorStopsWhenConsumerIsDisposed()
+        {
+            using var enumerator = new TestDataEnumerator { MoveNextTrueCount = int.MaxValue };
+
+            var result = SubscriptionUtils.ScheduleEnumerator(Symbols.SPY, enumerator);
+
+            Assert.IsTrue(result.MoveNext());
+            result.DisposeSafely();
+            AssertDisposed(enumerator);
+        }
+
+        [Test]
+        public void ScheduleEnumeratorThrowingEnumeratorEndsConsumer()
+        {
+            using var enumerator = new TestDataEnumerator { MoveNextTrueCount = 10, ThrowException = true };
+
+            using var result = SubscriptionUtils.ScheduleEnumerator(Symbols.SPY, enumerator);
+
+            Assert.IsFalse(result.MoveNext());
+            AssertDisposed(enumerator);
+        }
+
+        private static void AssertDisposed(dynamic enumerator)
+        {
+            var count = 0;
+            while (!enumerator.Disposed)
+            {
+                if (count++ > 500)
+                {
+                    Assert.Fail("Timeout waiting for the worker to dispose of the enumerator");
+                }
+                Thread.Sleep(1);
+            }
+        }
+
+        private class TestSequenceEnumerator : IEnumerator<BaseData>
+        {
+            private readonly IEnumerator<BaseData> _enumerator;
+
+            public bool Disposed { get; private set; }
+
+            public TestSequenceEnumerator(List<BaseData> data)
+            {
+                _enumerator = data.GetEnumerator();
+            }
+
+            public void Dispose()
+            {
+                Disposed = true;
+                _enumerator.Dispose();
+            }
+
+            public bool MoveNext()
+            {
+                return _enumerator.MoveNext();
+            }
+
+            public void Reset()
+            {
+            }
+
+            public BaseData Current => _enumerator.Current;
+
+            object IEnumerator.Current => Current;
+        }
+
         private class TestDataEnumerator : IEnumerator<BaseData>
         {
             public bool ThrowException { get; set; }


### PR DESCRIPTION
## Description

In live trading, each subscription's warmup enumerator performs blocking IO — history requests, disk reads and remote or custom data source fetches — and was driven directly by the synchronizer thread, so subscriptions warmed up strictly sequentially. For large universes (thousands of subscriptions) the first time slice could take longer than the isolator's single time loop limit, killing the deploy before warmup completed: ~6,000 history requests at ~90ms each is ~9 minutes of serialized fetching.

`LiveTradingDataFeed` now schedules the warmup enumeration on the `WeightedWorkScheduler` workers through a new `SubscriptionUtils.ScheduleEnumerator` helper, which feeds a blocking `EnqueueableEnumerator` the synchronizer consumes. Subscriptions warm up concurrently while the synchronizer only blocks until each subscription's next data point is available, preserving the existing ordering guarantees (including the `lastPointTracker` history start time adjustment, since each subscription's chain still runs in order on its worker). A null data point ends the warmup enumeration, mirroring how the concat enumerator interprets it in live mode.

The worker production loop is shared with the existing `CreateAndScheduleWorker` (same batch sizing, disposal and weight prioritization semantics — behavior preserved, including forwarding null data points on that path).

Since these workers were previously unused in live trading, `data-feed-workers-count` now defaults to 2 and `data-feed-max-work-weight` to 100 in live mode to bound cpu and memory usage (worst case ~130MB for 6,000 minute subscriptions with 100 points buffered each; worker threads run at lowest priority). Both remain configurable, and backtesting defaults are unchanged.

Also sets the server statistics on the final backtest result before storing it and its summary, instead of only before sending the final packet, for consistency with live trading.

## Testing

- New `SubscriptionUtilsTests` covering `ScheduleEnumerator`: ordering across work batches, ending on a null data point, stopping when the consumer is disposed, and ending the consumer when the source throws.
- `Engine.DataFeeds` test namespace green (the only failures — `DoesNotLeakMemory`, `UniverseSelectionAddAndRemove` — reproduce identically on master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)