### PR TITLE
Run SubscriptionUtilsTests cases sequentially

### DIFF
--- a/Tests/Engine/DataFeeds/SubscriptionUtilsTests.cs
+++ b/Tests/Engine/DataFeeds/SubscriptionUtilsTests.cs
@@ -32,7 +32,7 @@ using QuantConnect.Util;
 
 namespace QuantConnect.Tests.Engine.DataFeeds
 {
-    [TestFixture, Parallelizable(ParallelScope.All)]
+    [TestFixture, Parallelizable(ParallelScope.Fixtures)]
     public class SubscriptionUtilsTests
     {
         private Security _security;


### PR DESCRIPTION
## Description

`SubscriptionUtilsTests` is marked `Parallelizable(ParallelScope.All)`, which runs its test cases concurrently on the shared fixture instance, while `[SetUp]` recreates the shared `_security`/`_config` fields per case. Concurrent cases can therefore operate on the same `SubscriptionDataConfig` instance: a case with price scaling enabled writes `PriceScaleFactor` on it mid-run, racing a sibling case's assertions — producing rare, timing-dependent failures in the `PriceScale*` tests (e.g. a fill-forward point observed with the wrong scale).

Switch the fixture to `ParallelScope.Fixtures`, matching the convention used across the rest of the suite: the fixture still runs in parallel with other fixtures, but its cases run sequentially, so the shared fixture state is safe.

## Testing

- Fixture green (12/12); full suite unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)