### PR TITLE
Reject a ChoppinessIndex period of one

### DIFF
--- a/Indicators/ChoppinessIndex.cs
+++ b/Indicators/ChoppinessIndex.cs
@@ -46,10 +46,15 @@ namespace QuantConnect.Indicators
         /// Creates a new ChoppinessIndex indicator using the specified period and moving average type
         /// </summary>
         /// <param name="name">The name of this indicator</param>
-        /// <param name="period">The period used for rolling windows for highs and lows</param>
+        /// <param name="period">The period used for rolling windows for highs and lows, must be greater than one</param>
         public ChoppinessIndex(string name, int period)
             : base(name)
         {
+            if (period < 2)
+            {
+                throw new ArgumentException($"Period parameter for ChoppinessIndex indicator must be greater than 1 but was {period}");
+            }
+
             _period = period;
 
             _trueRange = new TrueRange();
@@ -64,7 +69,7 @@ namespace QuantConnect.Indicators
         /// <summary>
         /// Creates a new ChoppinessIndex indicator using the specified period
         /// </summary>
-        /// <param name="period">The period used for rolling windows for highs and lows</param>
+        /// <param name="period">The period used for rolling windows for highs and lows, must be greater than one</param>
         public ChoppinessIndex(int period)
             : this($"CHOP({period})", period)
         {

--- a/Tests/Indicators/ChoppinessIndexTests.cs
+++ b/Tests/Indicators/ChoppinessIndexTests.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
 */
 
+using System;
 using NUnit.Framework;
 using QuantConnect.Data.Market;
 using QuantConnect.Indicators;
@@ -32,5 +33,14 @@ namespace QuantConnect.Tests.Indicators
         protected override string TestFileName => "spy_with_chop.csv";
 
         protected override string TestColumnName => "CHOP14";
+
+        [Test]
+        public void PeriodBelowMinimumThrows()
+        {
+            var period = 1;
+
+            var exception = Assert.Throws<ArgumentException>(() => new ChoppinessIndex(period));
+            Assert.That(exception.Message, Is.EqualTo($"Period parameter for ChoppinessIndex indicator must be greater than 1 but was {period}"));
+        }
     }
 }


### PR DESCRIPTION
#### Description

`ChoppinessIndex` now rejects a period below two in its constructor.

#### Related Issue

Closes #9724

#### Motivation and Context

`ComputeNextValue` divides by `Math.Log10(_period)`. At a period of one that divisor is zero, so the double is infinite and the cast to decimal throws `OverflowException` on the first update after warm-up. The constructor took the value without complaint, so the failure landed on the data rather than on the call that was wrong.

`ValueAtRisk`, `Beta`, `Correlation` and `Covariance` already reject a period their formula cannot use, with one message shape between them. This uses the same sentence.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

`ChoppinessIndexTests.PeriodBelowMinimumThrows`, copied from `ValueAtRiskTests.PeriodBelowMinimumThrows`.

Keeping the test and reverting only `Indicators/ChoppinessIndex.cs`:

```
Failed!  Failed: 1, Passed: 11, Total: 12
```

with the source in place:

```
Passed!  Failed: 0, Passed: 12, Total: 12
```

The red run reports no exception at all at construction, which is the defect.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`