### PR TITLE
Reject the two point window Beta, Correlation and Covariance describe

### DIFF
--- a/Indicators/Beta.cs
+++ b/Indicators/Beta.cs
@@ -59,7 +59,7 @@ namespace QuantConnect.Indicators
             : base(name, targetSymbol, referenceSymbol, 2)
         {
             // Assert the period is greater than two, otherwise the beta can not be computed
-            if (period < 2)
+            if (period < 3)
             {
                 throw new ArgumentException($"Period parameter for Beta indicator must be greater than 2 but was {period}.");
             }

--- a/Indicators/Beta.cs
+++ b/Indicators/Beta.cs
@@ -58,10 +58,10 @@ namespace QuantConnect.Indicators
         public Beta(string name, Symbol targetSymbol, Symbol referenceSymbol, int period)
             : base(name, targetSymbol, referenceSymbol, 2)
         {
-            // Assert the period is greater than two, otherwise the beta can not be computed
-            if (period < 3)
+            // Assert the period is greater than one, otherwise the beta can not be computed
+            if (period < 2)
             {
-                throw new ArgumentException($"Period parameter for Beta indicator must be greater than 2 but was {period}.");
+                throw new ArgumentException($"Period parameter for Beta indicator must be greater than 1 but was {period}.");
             }
 
             _targetReturns = new RollingWindow<double>(period);

--- a/Indicators/Correlation.cs
+++ b/Indicators/Correlation.cs
@@ -61,7 +61,7 @@ namespace QuantConnect.Indicators
             : base(name, targetSymbol, referenceSymbol, period)
         {
             // Assert the period is greater than two, otherwise the correlation can not be computed
-            if (period < 2)
+            if (period < 3)
             {
                 throw new ArgumentException($"Period parameter for Correlation indicator must be greater than 2 but was {period}");
             }

--- a/Indicators/Covariance.cs
+++ b/Indicators/Covariance.cs
@@ -52,7 +52,7 @@ namespace QuantConnect.Indicators
             : base(name, targetSymbol, referenceSymbol, 2)
         {
             // Assert the period is greater than two, otherwise the covariance can not be computed
-            if (period < 2)
+            if (period < 3)
             {
                 throw new ArgumentException($"Period parameter for Covariance indicator must be greater than 2 but was {period}.");
             }

--- a/Indicators/Covariance.cs
+++ b/Indicators/Covariance.cs
@@ -51,10 +51,10 @@ namespace QuantConnect.Indicators
         public Covariance(string name, Symbol targetSymbol, Symbol referenceSymbol, int period)
             : base(name, targetSymbol, referenceSymbol, 2)
         {
-            // Assert the period is greater than two, otherwise the covariance can not be computed
-            if (period < 3)
+            // Assert the period is greater than one, otherwise the covariance can not be computed
+            if (period < 2)
             {
-                throw new ArgumentException($"Period parameter for Covariance indicator must be greater than 2 but was {period}.");
+                throw new ArgumentException($"Period parameter for Covariance indicator must be greater than 1 but was {period}.");
             }
 
             _targetReturns = new RollingWindow<double>(period);

--- a/Tests/Indicators/BetaIndicatorTests.cs
+++ b/Tests/Indicators/BetaIndicatorTests.cs
@@ -316,13 +316,19 @@ namespace QuantConnect.Tests.Indicators
         [Test]
         public void PeriodBelowMinimumThrows()
         {
-            // A two point window leaves no spread to measure: the correlation of two
-            // points is 1 or -1 whatever the data says, so three is the smallest period
-            // that carries information
-            var period = 2;
+            // One return is not a sample, so the smallest period this can accept is two
+            var period = 1;
 
             var exception = Assert.Throws<ArgumentException>(() => new Beta(Symbols.SPY, Symbols.AAPL, period));
-            Assert.That(exception.Message, Is.EqualTo($"Period parameter for Beta indicator must be greater than 2 but was {period}."));
+            Assert.That(exception.Message, Is.EqualTo($"Period parameter for Beta indicator must be greater than 1 but was {period}."));
+        }
+
+        [Test]
+        public void PeriodOfTwoIsAccepted()
+        {
+            // Two returns give a finite, well defined beta, unlike the correlation
+            // of two points, which is 1 or -1 whatever the data says
+            Assert.DoesNotThrow(() => new Beta(Symbols.SPY, Symbols.AAPL, 2));
         }
     }
 }

--- a/Tests/Indicators/BetaIndicatorTests.cs
+++ b/Tests/Indicators/BetaIndicatorTests.cs
@@ -312,5 +312,17 @@ namespace QuantConnect.Tests.Indicators
                 Assert.AreEqual(Symbols.AAPL, indicator.Current.Symbol);
             }
         }
+
+        [Test]
+        public void PeriodBelowMinimumThrows()
+        {
+            // A two point window leaves no spread to measure: the correlation of two
+            // points is 1 or -1 whatever the data says, so three is the smallest period
+            // that carries information
+            var period = 2;
+
+            var exception = Assert.Throws<ArgumentException>(() => new Beta(Symbols.SPY, Symbols.AAPL, period));
+            Assert.That(exception.Message, Is.EqualTo($"Period parameter for Beta indicator must be greater than 2 but was {period}."));
+        }
     }
 }

--- a/Tests/Indicators/CorrelationPearsonTests.cs
+++ b/Tests/Indicators/CorrelationPearsonTests.cs
@@ -223,5 +223,17 @@ namespace QuantConnect.Tests.Indicators
             }
             Assert.AreEqual(1, (double)indicator.Current.Value);
         }
+
+        [Test]
+        public void PeriodBelowMinimumThrows()
+        {
+            // A two point window leaves no spread to measure: the correlation of two
+            // points is 1 or -1 whatever the data says, so three is the smallest period
+            // that carries information
+            var period = 2;
+
+            var exception = Assert.Throws<ArgumentException>(() => new Correlation(Symbols.SPY, Symbols.AAPL, period));
+            Assert.That(exception.Message, Is.EqualTo($"Period parameter for Correlation indicator must be greater than 2 but was {period}"));
+        }
     }
 }

--- a/Tests/Indicators/CovarianceTests.cs
+++ b/Tests/Indicators/CovarianceTests.cs
@@ -291,13 +291,19 @@ namespace QuantConnect.Tests.Indicators
         [Test]
         public void PeriodBelowMinimumThrows()
         {
-            // A two point window leaves no spread to measure: the correlation of two
-            // points is 1 or -1 whatever the data says, so three is the smallest period
-            // that carries information
-            var period = 2;
+            // One return is not a sample, so the smallest period this can accept is two
+            var period = 1;
 
             var exception = Assert.Throws<ArgumentException>(() => new Covariance(Symbols.SPY, Symbols.AAPL, period));
-            Assert.That(exception.Message, Is.EqualTo($"Period parameter for Covariance indicator must be greater than 2 but was {period}."));
+            Assert.That(exception.Message, Is.EqualTo($"Period parameter for Covariance indicator must be greater than 1 but was {period}."));
+        }
+
+        [Test]
+        public void PeriodOfTwoIsAccepted()
+        {
+            // Two returns give a finite, well defined covariance, unlike the correlation
+            // of two points, which is 1 or -1 whatever the data says
+            Assert.DoesNotThrow(() => new Covariance(Symbols.SPY, Symbols.AAPL, 2));
         }
     }
 }

--- a/Tests/Indicators/CovarianceTests.cs
+++ b/Tests/Indicators/CovarianceTests.cs
@@ -287,5 +287,17 @@ namespace QuantConnect.Tests.Indicators
                 Assert.AreEqual(Symbols.AAPL, indicator.Current.Symbol);
             }
         }
+
+        [Test]
+        public void PeriodBelowMinimumThrows()
+        {
+            // A two point window leaves no spread to measure: the correlation of two
+            // points is 1 or -1 whatever the data says, so three is the smallest period
+            // that carries information
+            var period = 2;
+
+            var exception = Assert.Throws<ArgumentException>(() => new Covariance(Symbols.SPY, Symbols.AAPL, period));
+            Assert.That(exception.Message, Is.EqualTo($"Period parameter for Covariance indicator must be greater than 2 but was {period}."));
+        }
     }
 }


### PR DESCRIPTION
#### Description

`Beta`, `Correlation` and `Covariance` now test `period < 3`, which is the bound their comment and their message already state.

#### Related Issue

Closes #9725

#### Motivation and Context

All three carry the comment "assert the period is greater than two", raise "must be greater than 2 but was {period}", and then test `period < 2`, so a period of two reaches the calculation.

Two points always correlate perfectly. Fed ten bars of two series that are not proportional, `Correlation` at period 2 returns 1 or -1 on every one of its nine readings:

```
period  2: 1 -1 -1 -1 -1 -1 -1 -1 -1
period  3: 0.3273 -0.2402 -0.2402 -0.3974 -0.2895 -0.2895 -0.2895 -0.2895
period  4: 0.3586 0 -0.049 -0.0804 -0.0476 -0.0476 -0.0476
period 10: 0.749
```

`Beta` and `Covariance` share that window through `DualSymbolIndicator`.

`ValueAtRisk` states the same bound and tests `period < 3`.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

One test per indicator, copied from `ValueAtRiskTests.PeriodBelowMinimumThrows`.

Keeping the tests and reverting the three source files:

```
Failed!  Failed: 3, Passed: 45, Total: 48
```

with them in place, including the Spearman fixture:

```
Passed!  Failed: 0, Passed: 64, Total: 64
```

Nothing in `Tests/`, `Algorithm.CSharp/` or `Algorithm.Python/` constructs any of the three with a period of 2, so no existing caller changes; the smallest literal in use is 3.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`