### PR TITLE
Run the reset contract over every indicator, not only the tested ones

### DIFF
--- a/Tests/Indicators/IndicatorResetContractTests.cs
+++ b/Tests/Indicators/IndicatorResetContractTests.cs
@@ -29,11 +29,12 @@ namespace QuantConnect.Tests.Indicators
     /// the ones with a test class deriving from <see cref="CommonIndicatorTests{T}"/>.
     /// </summary>
     /// <remarks>
-    /// A field left set by the first pass changes the second, which is what a reset defect
-    /// looks like from the outside. Several periods, because a field assigned on an early
-    /// return during warm-up is overwritten on the first update at any larger period.
-    /// A type that cannot be constructed or fed is reported with its reason by
-    /// <see cref="Assert.Ignore(string)"/>.
+    /// A field left set by the first pass changes the second. Several periods, because a
+    /// field assigned on an early return during warm-up is overwritten at any larger one.
+    /// A two symbol indicator gets a bar per symbol stamped alike, since
+    /// <see cref="MultiSymbolIndicator{T}"/> fills its windows only on a shared time.
+    /// A type that cannot be constructed or fed is reported by
+    /// <see cref="Assert.Ignore(string)"/>, with a count of how many warmed up.
     /// </remarks>
     [TestFixture]
     public class IndicatorResetContractTests
@@ -44,11 +45,9 @@ namespace QuantConnect.Tests.Indicators
 
         private static readonly DateTime StartDate = new DateTime(2020, 1, 1);
 
-        private static readonly Symbol Target =
-            new Symbol(SecurityIdentifier.GenerateEquity("SPY", Market.USA, mapSymbol: false), "SPY");
+        private static readonly Symbol Target = Symbols.SPY;
 
-        private static readonly Symbol Reference =
-            new Symbol(SecurityIdentifier.GenerateEquity("IBM", Market.USA, mapSymbol: false), "IBM");
+        private static readonly Symbol Reference = Symbols.IBM;
 
         private static IEnumerable<TestCaseData> Cases()
         {
@@ -61,8 +60,7 @@ namespace QuantConnect.Tests.Indicators
             {
                 foreach (var period in Periods)
                 {
-                    // {m} is the test method, without which the two contracts name their
-                    // cases identically.
+                    // {m} is the test method; without it the two contracts collide.
                     yield return new TestCaseData(indicator, period)
                         .SetName($"{{m}}({indicator.Name}, period {period.ToString(CultureInfo.InvariantCulture)})");
                 }
@@ -73,7 +71,7 @@ namespace QuantConnect.Tests.Indicators
         [TestCaseSource(nameof(Cases))]
         public void ProducesTheSameValuesAfterReset(Type type, int period)
         {
-            var indicator = Construct(type, period, out var rejected);
+            var indicator = Construct(type, period, out var rejected, out var symbols);
             if (indicator == null)
             {
                 Assert.Ignore(Skip(type, period, rejected));
@@ -83,7 +81,7 @@ namespace QuantConnect.Tests.Indicators
             var count = SampleCount(indicator, period);
 
             var before = new List<Sample>();
-            var reason = Feed(indicator, type, count, before);
+            var reason = Feed(indicator, type, count, symbols, before);
             if (reason != null)
             {
                 Assert.Ignore(Skip(type, period, reason));
@@ -93,14 +91,15 @@ namespace QuantConnect.Tests.Indicators
                 Assert.Ignore(Skip(type, period, "accepted the replay without recording a sample"));
             }
 
+            Record(indicator.IsReady);
             indicator.Reset();
 
             var after = new List<Sample>();
-            var second = Feed(indicator, type, count, after);
+            var second = Feed(indicator, type, count, symbols, after);
 
-            // The series was accepted once already, so failing it now is itself a defect.
             Assert.IsNull(second, $"{Where(type, period)} accepted the series, then failed it after Reset: {second}");
             Assert.AreEqual(before.Count, after.Count, $"{Where(type, period)} produced fewer values after Reset");
+
 
             for (var i = 0; i < before.Count; i++)
             {
@@ -116,7 +115,7 @@ namespace QuantConnect.Tests.Indicators
         [TestCaseSource(nameof(Cases))]
         public void ResetsToDefaultState(Type type, int period)
         {
-            var indicator = Construct(type, period, out var rejected);
+            var indicator = Construct(type, period, out var rejected, out var symbols);
             if (indicator == null)
             {
                 Assert.Ignore(Skip(type, period, rejected));
@@ -125,7 +124,7 @@ namespace QuantConnect.Tests.Indicators
             RegisterTrackedSymbols(indicator, type);
             var count = SampleCount(indicator, period);
 
-            var reason = Feed(indicator, type, count, new List<Sample>());
+            var reason = Feed(indicator, type, count, symbols, new List<Sample>());
             if (reason != null)
             {
                 Assert.Ignore(Skip(type, period, reason));
@@ -147,7 +146,6 @@ namespace QuantConnect.Tests.Indicators
             }
             catch (TargetInvocationException exception)
             {
-                // The helper asserts without a message.
                 Assert.Fail($"{Where(type, period)} is not in its default state after Reset. "
                     + exception.InnerException?.Message);
             }
@@ -161,10 +159,8 @@ namespace QuantConnect.Tests.Indicators
 
         private static Symbol OptionOn(Symbol underlying)
         {
-            return new Symbol(
-                SecurityIdentifier.GenerateOption(
-                    new DateTime(2020, 6, 19), underlying.ID, Market.USA, 300m, OptionRight.Call, OptionStyle.American),
-                underlying.Value);
+            return Symbols.CreateOptionSymbol(
+                underlying.Value, OptionRight.Call, 300m, new DateTime(2020, 6, 19));
         }
 
         private static string Where(Type type, int period)
@@ -183,7 +179,42 @@ namespace QuantConnect.Tests.Indicators
             return 100m + (0.37m * index) + (index % 5 == 0 ? 1.9m : 0m);
         }
 
-        // 21 of 188 never became ready inside 40 bars at a period of 14.
+        // Correlated with the target without repeating it, so a covariance over the
+        // pair is neither zero nor degenerate.
+        private static decimal ReferencePrice(int index)
+        {
+            return 50m + (0.19m * index) + (index % 7 == 0 ? 1.1m : 0m);
+        }
+
+        private static int _cases;
+
+        private static int _ready;
+
+        // A case replayed without warming up asserts nothing, and reads as a pass.
+        private static void Record(bool ready)
+        {
+            _cases++;
+            if (ready)
+            {
+                _ready++;
+            }
+        }
+
+        [OneTimeSetUp]
+        public void ResetCounts()
+        {
+            _cases = 0;
+            _ready = 0;
+        }
+
+        [OneTimeTearDown]
+        public void ReportReadiness()
+        {
+            TestContext.Progress.WriteLine(
+                $"reset contract: {_ready.ToString(CultureInfo.InvariantCulture)} of "
+                + $"{_cases.ToString(CultureInfo.InvariantCulture)} replayed cases were ready when Reset was called");
+        }
+
         private static int SampleCount(IIndicator indicator, int period)
         {
             var warmUp = (indicator as IIndicatorWarmUpPeriodProvider)?.WarmUpPeriod ?? period;
@@ -202,17 +233,20 @@ namespace QuantConnect.Tests.Indicators
             return null;
         }
 
-        // Returns null and the reason the last candidate refused.
-        private static IIndicator Construct(Type type, int period, out string rejected)
+        // Returns null and the reason the last candidate refused. `symbols` is how many
+        // the winning constructor took, which decides how Feed drives it.
+        private static IIndicator Construct(Type type, int period, out string rejected, out int symbols)
         {
             rejected = "has no constructor this fixture can fill";
+            symbols = 0;
             foreach (var constructor in type.GetConstructors().OrderBy(x => x.GetParameters().Length))
             {
-                var arguments = Arguments(type, period, constructor.GetParameters());
+                var arguments = Arguments(type, period, constructor.GetParameters(), out var taken);
                 if (arguments == null)
                 {
                     continue;
                 }
+                symbols = taken;
                 try
                 {
                     return (IIndicator)constructor.Invoke(arguments);
@@ -227,11 +261,12 @@ namespace QuantConnect.Tests.Indicators
             return null;
         }
 
-        private static object[] Arguments(Type type, int period, ParameterInfo[] parameters)
+        private static object[] Arguments(Type type, int period, ParameterInfo[] parameters, out int taken)
         {
             var arguments = new object[parameters.Length];
             var integers = 0;
             var symbols = 0;
+            taken = 0;
             for (var i = 0; i < parameters.Length; i++)
             {
                 var parameter = parameters[i];
@@ -239,9 +274,8 @@ namespace QuantConnect.Tests.Indicators
 
                 if (parameterType == typeof(Symbol) && !parameter.HasDefaultValue)
                 {
-                    // The option indicators read option.Underlying. Alpha rejects a target
-                    // equal to its reference. Counted among the symbols, because
-                    // Covariance(string, int, Symbol, Symbol) puts neither first.
+                    // Option indicators read option.Underlying, and Alpha rejects a target
+                    // equal to its reference. Covariance puts neither symbol first.
                     arguments[i] = IsOption(parameter)
                         ? OptionOn(Target)
                         : symbols == 0 ? Target : Reference;
@@ -275,7 +309,7 @@ namespace QuantConnect.Tests.Indicators
                 }
                 else if (InputType(parameterType) != null && !parameterType.IsAbstract && !parameterType.IsGenericTypeDefinition)
                 {
-                    arguments[i] = Construct(parameterType, period, out _);
+                    arguments[i] = Construct(parameterType, period, out _, out _);
                     if (arguments[i] == null)
                     {
                         return null;
@@ -286,6 +320,7 @@ namespace QuantConnect.Tests.Indicators
                     return null;
                 }
             }
+            taken = symbols;
             return arguments;
         }
 
@@ -311,36 +346,41 @@ namespace QuantConnect.Tests.Indicators
         }
 
         // Returns the reason the indicator could not be driven, or null when it was.
-        private static string Feed(IIndicator indicator, Type type, int count, List<Sample> samples)
+        // Two symbol indicators need a bar per symbol on the same timestamp, or their
+        // windows never fill.
+        private static string Feed(IIndicator indicator, Type type, int count, int symbols, List<Sample> samples)
         {
             var input = InputType(type);
+            var stream = symbols > 1 ? new[] { Target, Reference } : new[] { Target };
             for (var i = 0; i < count; i++)
             {
                 var time = StartDate.AddDays(i);
-                var price = Price(i);
-
-                try
+                foreach (var symbol in stream)
                 {
-                    if (input == typeof(IndicatorDataPoint))
+                    var price = symbol == Reference ? ReferencePrice(i) : Price(i);
+                    try
                     {
-                        indicator.Update(new IndicatorDataPoint(Target, time, price));
+                        if (input == typeof(IndicatorDataPoint))
+                        {
+                            indicator.Update(new IndicatorDataPoint(symbol, time, price));
+                        }
+                        else if (input.IsAssignableFrom(typeof(TradeBar)))
+                        {
+                            // A TradeBar satisfies IBaseDataBar, BaseData and IBaseData alike
+                            indicator.Update(new TradeBar(time, symbol, price, price + 1m, price - 1m, price + 0.5m, 1000 + i));
+                        }
+                        else
+                        {
+                            return $"takes {input.Name}, which this fixture does not feed";
+                        }
                     }
-                    else if (input.IsAssignableFrom(typeof(TradeBar)))
+                    catch (Exception exception)
                     {
-                        // A TradeBar satisfies IBaseDataBar, BaseData and IBaseData alike
-                        indicator.Update(new TradeBar(time, Target, price, price + 1m, price - 1m, price + 0.5m, 1000 + i));
+                        // An indicator that cannot survive the series says nothing about reset,
+                        // so the exception is reported rather than failed.
+                        return $"threw on sample {i.ToString(CultureInfo.InvariantCulture)}: "
+                            + exception.GetBaseException().Message;
                     }
-                    else
-                    {
-                        return $"takes {input.Name}, which this fixture does not feed";
-                    }
-                }
-                catch (Exception exception)
-                {
-                    // An indicator that cannot survive the series says nothing about reset,
-                    // so the exception is reported rather than failed.
-                    return $"threw on sample {i.ToString(CultureInfo.InvariantCulture)}: "
-                        + exception.GetBaseException().Message;
                 }
 
                 samples.Add(new Sample(indicator.Current.Value, indicator.IsReady));

--- a/Tests/Indicators/IndicatorResetContractTests.cs
+++ b/Tests/Indicators/IndicatorResetContractTests.cs
@@ -1,0 +1,364 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using QuantConnect.Data.Market;
+using QuantConnect.Indicators;
+
+namespace QuantConnect.Tests.Indicators
+{
+    /// <summary>
+    /// Asserts the reset contract against every indicator in the assembly rather than only
+    /// the ones with a test class deriving from <see cref="CommonIndicatorTests{T}"/>.
+    /// </summary>
+    /// <remarks>
+    /// A field left set by the first pass changes the second, which is what a reset defect
+    /// looks like from the outside. Several periods, because a field assigned on an early
+    /// return during warm-up is overwritten on the first update at any larger period.
+    /// A type that cannot be constructed or fed is reported with its reason by
+    /// <see cref="Assert.Ignore(string)"/>.
+    /// </remarks>
+    [TestFixture]
+    public class IndicatorResetContractTests
+    {
+        private static readonly int[] Periods = { 1, 2, 14 };
+
+        private const int MinimumSamples = 40;
+
+        private static readonly DateTime StartDate = new DateTime(2020, 1, 1);
+
+        private static readonly Symbol Target =
+            new Symbol(SecurityIdentifier.GenerateEquity("SPY", Market.USA, mapSymbol: false), "SPY");
+
+        private static readonly Symbol Reference =
+            new Symbol(SecurityIdentifier.GenerateEquity("IBM", Market.USA, mapSymbol: false), "IBM");
+
+        private static IEnumerable<TestCaseData> Cases()
+        {
+            var indicators = typeof(IndicatorBase).Assembly.GetTypes()
+                .Where(type => type.IsClass && type.IsPublic && !type.IsAbstract && !type.IsGenericTypeDefinition)
+                .Where(type => InputType(type) != null)
+                .OrderBy(type => type.Name);
+
+            foreach (var indicator in indicators)
+            {
+                foreach (var period in Periods)
+                {
+                    // {m} is the test method, without which the two contracts name their
+                    // cases identically.
+                    yield return new TestCaseData(indicator, period)
+                        .SetName($"{{m}}({indicator.Name}, period {period.ToString(CultureInfo.InvariantCulture)})");
+                }
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(Cases))]
+        public void ProducesTheSameValuesAfterReset(Type type, int period)
+        {
+            var indicator = Construct(type, period, out var rejected);
+            if (indicator == null)
+            {
+                Assert.Ignore(Skip(type, period, rejected));
+            }
+
+            RegisterTrackedSymbols(indicator, type);
+            var count = SampleCount(indicator, period);
+
+            var before = new List<Sample>();
+            var reason = Feed(indicator, type, count, before);
+            if (reason != null)
+            {
+                Assert.Ignore(Skip(type, period, reason));
+            }
+            if (indicator.Samples == 0)
+            {
+                Assert.Ignore(Skip(type, period, "accepted the replay without recording a sample"));
+            }
+
+            indicator.Reset();
+
+            var after = new List<Sample>();
+            var second = Feed(indicator, type, count, after);
+
+            // The series was accepted once already, so failing it now is itself a defect.
+            Assert.IsNull(second, $"{Where(type, period)} accepted the series, then failed it after Reset: {second}");
+            Assert.AreEqual(before.Count, after.Count, $"{Where(type, period)} produced fewer values after Reset");
+
+            for (var i = 0; i < before.Count; i++)
+            {
+                var at = i.ToString(CultureInfo.InvariantCulture);
+                Assert.AreEqual(before[i].Value, after[i].Value,
+                    $"{Where(type, period)} returned a different value at index {at} after Reset");
+                Assert.AreEqual(before[i].IsReady, after[i].IsReady,
+                    $"{Where(type, period)} reported a different IsReady at index {at} after Reset");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(Cases))]
+        public void ResetsToDefaultState(Type type, int period)
+        {
+            var indicator = Construct(type, period, out var rejected);
+            if (indicator == null)
+            {
+                Assert.Ignore(Skip(type, period, rejected));
+            }
+
+            RegisterTrackedSymbols(indicator, type);
+            var count = SampleCount(indicator, period);
+
+            var reason = Feed(indicator, type, count, new List<Sample>());
+            if (reason != null)
+            {
+                Assert.Ignore(Skip(type, period, reason));
+            }
+            if (indicator.Samples == 0)
+            {
+                Assert.Ignore(Skip(type, period, "accepted the replay without recording a sample"));
+            }
+
+            indicator.Reset();
+
+            // The assertion CommonIndicatorTests already makes, generic on the input type.
+            var assert = typeof(TestHelper)
+                .GetMethod(nameof(TestHelper.AssertIndicatorIsInDefaultState))
+                .MakeGenericMethod(InputType(type));
+            try
+            {
+                assert.Invoke(null, new object[] { indicator });
+            }
+            catch (TargetInvocationException exception)
+            {
+                // The helper asserts without a message.
+                Assert.Fail($"{Where(type, period)} is not in its default state after Reset. "
+                    + exception.InnerException?.Message);
+            }
+        }
+
+        private static bool IsOption(ParameterInfo parameter)
+        {
+            return parameter.Name != null
+                && parameter.Name.Contains("option", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static Symbol OptionOn(Symbol underlying)
+        {
+            return new Symbol(
+                SecurityIdentifier.GenerateOption(
+                    new DateTime(2020, 6, 19), underlying.ID, Market.USA, 300m, OptionRight.Call, OptionStyle.American),
+                underlying.Value);
+        }
+
+        private static string Where(Type type, int period)
+        {
+            return $"{type.Name} at period {period.ToString(CultureInfo.InvariantCulture)}";
+        }
+
+        private static string Skip(Type type, int period, string reason)
+        {
+            return $"{Where(type, period)}: {reason}";
+        }
+
+        // A repeating series hides a carried-over price. This one never revisits a level.
+        private static decimal Price(int index)
+        {
+            return 100m + (0.37m * index) + (index % 5 == 0 ? 1.9m : 0m);
+        }
+
+        // 21 of 188 never became ready inside 40 bars at a period of 14.
+        private static int SampleCount(IIndicator indicator, int period)
+        {
+            var warmUp = (indicator as IIndicatorWarmUpPeriodProvider)?.WarmUpPeriod ?? period;
+            return Math.Max(MinimumSamples, (2 * warmUp) + 2);
+        }
+
+        private static Type InputType(Type type)
+        {
+            for (var current = type; current != null; current = current.BaseType)
+            {
+                if (current.IsGenericType && current.GetGenericTypeDefinition() == typeof(IndicatorBase<>))
+                {
+                    return current.GetGenericArguments()[0];
+                }
+            }
+            return null;
+        }
+
+        // Returns null and the reason the last candidate refused.
+        private static IIndicator Construct(Type type, int period, out string rejected)
+        {
+            rejected = "has no constructor this fixture can fill";
+            foreach (var constructor in type.GetConstructors().OrderBy(x => x.GetParameters().Length))
+            {
+                var arguments = Arguments(type, period, constructor.GetParameters());
+                if (arguments == null)
+                {
+                    continue;
+                }
+                try
+                {
+                    return (IIndicator)constructor.Invoke(arguments);
+                }
+                catch (Exception exception)
+                {
+                    // FractalAdaptiveMovingAverage rejects an odd N, and it is not alone.
+                    rejected = "was refused by every constructor, last saying: "
+                        + exception.GetBaseException().Message;
+                }
+            }
+            return null;
+        }
+
+        private static object[] Arguments(Type type, int period, ParameterInfo[] parameters)
+        {
+            var arguments = new object[parameters.Length];
+            var integers = 0;
+            var symbols = 0;
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                var parameter = parameters[i];
+                var parameterType = Nullable.GetUnderlyingType(parameter.ParameterType) ?? parameter.ParameterType;
+
+                if (parameterType == typeof(Symbol) && !parameter.HasDefaultValue)
+                {
+                    // The option indicators read option.Underlying. Alpha rejects a target
+                    // equal to its reference. Counted among the symbols, because
+                    // Covariance(string, int, Symbol, Symbol) puts neither first.
+                    arguments[i] = IsOption(parameter)
+                        ? OptionOn(Target)
+                        : symbols == 0 ? Target : Reference;
+                    symbols++;
+                }
+                else if (parameter.HasDefaultValue)
+                {
+                    arguments[i] = parameter.DefaultValue;
+                }
+                else if (parameterType == typeof(string))
+                {
+                    arguments[i] = type.Name;
+                }
+                else if (parameterType == typeof(int))
+                {
+                    // Counted among the integers, so the first is the period the case names.
+                    arguments[i] = period + (2 * integers);
+                    integers++;
+                }
+                else if (parameterType == typeof(decimal))
+                {
+                    arguments[i] = 2m;
+                }
+                else if (parameterType == typeof(bool))
+                {
+                    arguments[i] = false;
+                }
+                else if (parameterType.IsEnum)
+                {
+                    arguments[i] = Enum.GetValues(parameterType).GetValue(0);
+                }
+                else if (InputType(parameterType) != null && !parameterType.IsAbstract && !parameterType.IsGenericTypeDefinition)
+                {
+                    arguments[i] = Construct(parameterType, period, out _);
+                    if (arguments[i] == null)
+                    {
+                        return null;
+                    }
+                }
+                else
+                {
+                    return null;
+                }
+            }
+            return arguments;
+        }
+
+        // The breadth indicators report not ready until an asset is tracked.
+        private static void RegisterTrackedSymbols(IIndicator indicator, Type type)
+        {
+            var add = type.GetMethod("Add", new[] { typeof(Symbol) });
+            if (add == null)
+            {
+                return;
+            }
+            foreach (var symbol in new[] { Target, Reference })
+            {
+                try
+                {
+                    add.Invoke(indicator, new object[] { symbol });
+                }
+                catch (Exception)
+                {
+                    return;
+                }
+            }
+        }
+
+        // Returns the reason the indicator could not be driven, or null when it was.
+        private static string Feed(IIndicator indicator, Type type, int count, List<Sample> samples)
+        {
+            var input = InputType(type);
+            for (var i = 0; i < count; i++)
+            {
+                var time = StartDate.AddDays(i);
+                var price = Price(i);
+
+                try
+                {
+                    if (input == typeof(IndicatorDataPoint))
+                    {
+                        indicator.Update(new IndicatorDataPoint(Target, time, price));
+                    }
+                    else if (input.IsAssignableFrom(typeof(TradeBar)))
+                    {
+                        // A TradeBar satisfies IBaseDataBar, BaseData and IBaseData alike
+                        indicator.Update(new TradeBar(time, Target, price, price + 1m, price - 1m, price + 0.5m, 1000 + i));
+                    }
+                    else
+                    {
+                        return $"takes {input.Name}, which this fixture does not feed";
+                    }
+                }
+                catch (Exception exception)
+                {
+                    // An indicator that cannot survive the series says nothing about reset,
+                    // so the exception is reported rather than failed.
+                    return $"threw on sample {i.ToString(CultureInfo.InvariantCulture)}: "
+                        + exception.GetBaseException().Message;
+                }
+
+                samples.Add(new Sample(indicator.Current.Value, indicator.IsReady));
+            }
+            return null;
+        }
+
+        private struct Sample
+        {
+            public Sample(decimal value, bool isReady)
+            {
+                Value = value;
+                IsReady = isReady;
+            }
+
+            public decimal Value { get; }
+
+            public bool IsReady { get; }
+        }
+    }
+}


### PR DESCRIPTION
#### Description

`Tests/Indicators/IndicatorResetContractTests.cs`, one new file. It constructs every indicator in the assembly by reflection, at three periods, and asserts two things: the same series replayed around a `Reset()` gives the same values and the same ready flag, and the indicator is back in its default state afterwards, using `TestHelper.AssertIndicatorIsInDefaultState`.

#### Related Issue

Closes #9726

#### Motivation and Context

`CommonIndicatorTests<T>` states eleven contracts and runs them only for an indicator with a test class deriving from it: 115 of the 202 concrete indicators. Six reset defects were merged this month out of that gap.

The case for it is not a bug count, since it is green on master. It is what happens when the six merged fixes are reverted, keeping the fixture:

```
Failed!  Failed: 21, Passed: 1121, Skipped: 70, Total: 1212
```

| merged fix | cases | how it shows |
|---|---|---|
| #9686 advance decline watermark | 12 | `IsReady` differs at index 1, across the four indicators sharing the base |
| #9687 ConnorsRSI previous input | 3 | the value differs, first at index 4 |
| #9688 SuperTrend previous close | 1 | the value differs at index 0, at period 1 only |
| #9694 MidPrice rolling extremes | 2 | the value differs at index 0, at periods 2 and 14 |
| #9705 IntradayVwap running sums | 3 | `IsReady` true after the reset |
| #9706 NewHighsNewLows readiness | 0 | the fixture registers assets, so the untracked state never arises |

Three notes on the shape, since each was a choice:

Three periods, because of #9688. `SuperTrend` assigned its previous close on the early return it takes while the average true range warms up, so at any period above one that return fires on the first update and the stale value never shows.

The price series never revisits a level. A repeating one caught two of the six, because a value carried across a reset is one the indicator meets again a few bars later anyway.

Anything unreachable is an `Assert.Ignore` carrying its reason, so the runner counts it and names it rather than passing over it. On master that is 70 cases over 18 indicators: 36 the fixture cannot construct, 18 that throw on the series, 16 where a constructor refuses that period and the ignore quotes the indicator's own message.

Two of the five that throw are worth a look on their own: `AutoRegressiveIntegratedMovingAverage` is #9714, and `ChoppinessIndex` at a period of one is #9724.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

```
Passed!  Failed: 0, Passed: 1142, Skipped: 70, Total: 1212, Duration: 391 ms
```

on `b0006b29a`, plus the reverted-fix run above. The neighbouring fixtures are unaffected: `IndicatorTests`, `ChoppinessIndexTests`, `MidPriceTests`, `SuperTrendTests`, `IntradayVwapTests`, `ConnorsRelativeStrengthIndexTests`, `AdvanceDeclineDifferenceTests` and `NewHighsNewLows` together give 0 failed.

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`