### PR TITLE
Skip stale live fill forward bars instead of back filling time jumps

### DIFF
--- a/Engine/DataFeeds/Enumerators/LiveFillForwardEnumerator.cs
+++ b/Engine/DataFeeds/Enumerators/LiveFillForwardEnumerator.cs
@@ -32,6 +32,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
         private readonly TimeSpan _dataResolution;
         private readonly TimeSpan _underlyingTimeout;
         private readonly ITimeProvider _timeProvider;
+        private readonly bool _extendedMarketHours;
+        private readonly DateTimeZone _dataTimeZone;
 
         private TimeSpan _marketCloseTimeSpan;
         private TimeSpan _marketOpenTimeSpan;
@@ -64,6 +66,8 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
             _timeProvider = timeProvider;
             _dataResolution = dataResolution.ToTimeSpan();
             _underlyingTimeout = GetMaximumDataTimeout(dataResolution);
+            _extendedMarketHours = isExtendedMarketHours;
+            _dataTimeZone = dataTimeZone;
         }
 
         /// <summary>
@@ -86,9 +90,48 @@ namespace QuantConnect.Lean.Engine.DataFeeds.Enumerators
                     underlyingTimeout = _underlyingTimeout;
                 }
 
+                var utcNow = _timeProvider.GetUtcNow();
                 var nextEndTimeUtc = (fillForward.EndTime + underlyingTimeout).ConvertToUtc(Exchange.TimeZone);
-                if (next != null || nextEndTimeUtc <= _timeProvider.GetUtcNow())
+                if (next != null || nextEndTimeUtc <= utcNow)
                 {
+                    // a candidate more than one fill forward period behind real time means we are catching up after a time jump,
+                    // for example the warmup to live handover: instead of back filling the whole gap bar by bar, skip to the
+                    // latest expected bar and fill forward from there to now
+                    if ((fillForward.EndTime + fillForwardResolution + underlyingTimeout).ConvertToUtc(Exchange.TimeZone) <= utcNow
+                        && fillForwardResolution <= Time.OneHour)
+                    {
+                        // jump the reference near real time in a single step: the latest expected bar is the single
+                        // trade bar ending at or before now, respecting open hours
+                        var exchangeNow = utcNow.ConvertFromUtc(Exchange.TimeZone);
+                        var targetEndTime = Time.GetStartTimeForTradeBars(Exchange.Hours, exchangeNow, fillForwardResolution, 1,
+                            _extendedMarketHours, _dataTimeZone) + fillForwardResolution;
+                        if (next != null)
+                        {
+                            // when real data is waiting, jump one period short of it so the regular fill forward
+                            // behavior takes over from there
+                            var nextTarget = next.Time.RoundDown(fillForwardResolution) - fillForwardResolution;
+                            if (nextTarget < targetEndTime)
+                            {
+                                targetEndTime = nextTarget;
+                            }
+                        }
+
+                        var jumpEndTime = targetEndTime - fillForwardResolution;
+                        if (jumpEndTime > fillForward.EndTime)
+                        {
+                            var period = fillForward.EndTime - fillForward.Time;
+                            var jumped = fillForward.Clone(fillForward: true);
+                            jumped.Time = jumpEndTime - period;
+                            jumped.EndTime = jumpEndTime;
+                            if (base.RequiresFillForwardData(fillForwardResolution, jumped, next, out var jumpedCandidate)
+                                && jumpedCandidate != null
+                                && (jumpedCandidate.EndTime + underlyingTimeout).ConvertToUtc(Exchange.TimeZone) <= utcNow)
+                            {
+                                fillForward = jumpedCandidate;
+                            }
+                        }
+                    }
+
                     // we FF if next is here but in the future or next has not come yet and we've wait enough time
                     return true;
                 }

--- a/Tests/Engine/DataFeeds/Enumerators/LiveFillForwardEnumeratorTests.cs
+++ b/Tests/Engine/DataFeeds/Enumerators/LiveFillForwardEnumeratorTests.cs
@@ -550,6 +550,209 @@ namespace QuantConnect.Tests.Engine.DataFeeds.Enumerators
             enqueueableEnumerator.Dispose();
         }
 
+        [TestCase(Resolution.Minute)]
+        [TestCase(Resolution.Second)]
+        public void SkipsStaleFillForwardBarsAfterTimeJump(Resolution fillForwardResolution)
+        {
+            var previousBarEndTime = new DateTime(2020, 5, 21, 10, 0, 0);
+            var timeProvider = new ManualTimeProvider(previousBarEndTime, TimeZones.NewYork);
+            using var fillForwardEnumerator = GetLiveFillForwardEnumerator(timeProvider, previousBarEndTime.Date, Resolution.Minute,
+                out var enqueueableEnumerator, dailyStrictEndTimeEnabled: false, fillForwardResolution);
+            var openingBar = new TradeBar(previousBarEndTime.AddMinutes(-1), Symbols.AAPL, 0.01m, 0.01m, 0.01m, 0.01m, 1, Time.OneMinute);
+
+            enqueueableEnumerator.Enqueue(openingBar);
+            Assert.IsTrue(fillForwardEnumerator.MoveNext());
+            Assert.AreEqual(openingBar.EndTime, fillForwardEnumerator.Current.EndTime);
+
+            // the clock jumps 30 minutes ahead at once, like the warmup to live handover does
+            var expectedBarEndTime = previousBarEndTime.AddMinutes(30);
+            timeProvider.SetCurrentTime(expectedBarEndTime.AddMilliseconds(100));
+
+            // a single fill forward bar is emitted, the latest expected one, instead of back filling the whole gap
+            Assert.IsTrue(fillForwardEnumerator.MoveNext());
+            Assert.IsNotNull(fillForwardEnumerator.Current);
+            Assert.IsTrue(fillForwardEnumerator.Current.IsFillForward);
+            Assert.AreEqual(expectedBarEndTime, fillForwardEnumerator.Current.EndTime);
+            Assert.AreEqual(openingBar.Open, ((TradeBar)fillForwardEnumerator.Current).Open);
+
+            // and nothing else to emit until time moves forward again
+            Assert.IsTrue(fillForwardEnumerator.MoveNext());
+            Assert.IsNull(fillForwardEnumerator.Current);
+
+            enqueueableEnumerator.Dispose();
+        }
+
+        [TestCase(Resolution.Minute, Resolution.Minute, false)]
+        [TestCase(Resolution.Minute, Resolution.Second, false)]
+        [TestCase(Resolution.Hour, Resolution.Minute, false)]
+        [TestCase(Resolution.Hour, Resolution.Second, false)]
+        [TestCase(Resolution.Second, Resolution.Second, false)]
+        [TestCase(Resolution.Daily, Resolution.Minute, false)]
+        [TestCase(Resolution.Daily, Resolution.Second, false)]
+        [TestCase(Resolution.Daily, Resolution.Minute, true)]
+        [TestCase(Resolution.Daily, Resolution.Second, true)]
+        public void SkipsStaleFillForwardBarsAfterTimeJumpCrossResolution(Resolution dataResolution, Resolution fillForwardResolution, bool dailyStrictEndTime)
+        {
+            DateTime previousBarTime;
+            DateTime previousBarEndTime;
+            if (dataResolution == Resolution.Daily)
+            {
+                if (dailyStrictEndTime)
+                {
+                    // Wednesday session
+                    previousBarTime = new DateTime(2020, 5, 20, 9, 30, 0);
+                    previousBarEndTime = new DateTime(2020, 5, 20, 16, 0, 0);
+                }
+                else
+                {
+                    previousBarTime = new DateTime(2020, 5, 20);
+                    previousBarEndTime = new DateTime(2020, 5, 21);
+                }
+            }
+            else
+            {
+                previousBarEndTime = new DateTime(2020, 5, 21, 10, 0, 0);
+                previousBarTime = previousBarEndTime - dataResolution.ToTimeSpan();
+            }
+
+            var timeProvider = new ManualTimeProvider(previousBarEndTime, TimeZones.NewYork);
+            using var fillForwardEnumerator = GetLiveFillForwardEnumerator(timeProvider, previousBarEndTime.Date, dataResolution,
+                out var enqueueableEnumerator, dailyStrictEndTime, fillForwardResolution);
+            var openingBar = new TradeBar(previousBarTime, Symbols.AAPL, 0.01m, 0.01m, 0.01m, 0.01m, 1, previousBarEndTime - previousBarTime);
+
+            enqueueableEnumerator.Enqueue(openingBar);
+            Assert.IsTrue(fillForwardEnumerator.MoveNext());
+            Assert.AreEqual(openingBar.EndTime, fillForwardEnumerator.Current.EndTime);
+
+            // the clock jumps ahead at once into Thursday's session, like the warmup to live handover does
+            var expectedBarEndTime = new DateTime(2020, 5, 21, 10, 30, 0);
+            timeProvider.SetCurrentTime(expectedBarEndTime.AddMilliseconds(100));
+
+            // a single fill forward bar is emitted, the latest expected one, instead of back filling the whole gap
+            Assert.IsTrue(fillForwardEnumerator.MoveNext());
+            Assert.IsNotNull(fillForwardEnumerator.Current);
+            Assert.IsTrue(fillForwardEnumerator.Current.IsFillForward);
+            Assert.AreEqual(expectedBarEndTime, fillForwardEnumerator.Current.EndTime);
+            Assert.AreEqual(openingBar.Open, ((TradeBar)fillForwardEnumerator.Current).Open);
+            // emitted bars keep the data resolution as their period, the fill forward resolution is only the emission grid
+            if (dataResolution != Resolution.Daily)
+            {
+                Assert.AreEqual(dataResolution.ToTimeSpan(), fillForwardEnumerator.Current.EndTime - fillForwardEnumerator.Current.Time);
+            }
+
+            // and nothing else to emit until time moves forward again
+            Assert.IsTrue(fillForwardEnumerator.MoveNext());
+            Assert.IsNull(fillForwardEnumerator.Current);
+
+            enqueueableEnumerator.Dispose();
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SkipRoundsDownOnTheDataTimeZoneGrid(bool halfHourOffsetDataTimeZone)
+        {
+            // the emission grid follows the data time zone: with a +5:30 offset data time zone, hour bars
+            // end at half past the hour in exchange (New York) time, with a whole hour offset they end on the hour
+            var dataTimeZone = halfHourOffsetDataTimeZone ? TimeZones.Kolkata : TimeZones.Utc;
+            var previousBarEndTime = halfHourOffsetDataTimeZone
+                ? new DateTime(2020, 5, 21, 10, 30, 0)
+                : new DateTime(2020, 5, 21, 10, 0, 0);
+            var expectedBarEndTime = halfHourOffsetDataTimeZone
+                ? new DateTime(2020, 5, 21, 13, 30, 0)
+                : new DateTime(2020, 5, 21, 13, 0, 0);
+
+            var exchange = new SecurityExchange(SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork));
+            var timeProvider = new ManualTimeProvider(previousBarEndTime, TimeZones.NewYork);
+            var enqueueableEnumerator = new EnqueueableEnumerator<BaseData>();
+            using var fillForwardEnumerator = new LiveFillForwardEnumerator(timeProvider, enqueueableEnumerator, exchange,
+                Ref.Create(Time.OneHour), false, previousBarEndTime.Date, Time.EndOfTime, Resolution.Hour, dataTimeZone, false);
+            var openingBar = new TradeBar(previousBarEndTime.AddHours(-1), Symbols.EURUSD, 0.01m, 0.01m, 0.01m, 0.01m, 1, Time.OneHour);
+
+            enqueueableEnumerator.Enqueue(openingBar);
+            Assert.IsTrue(fillForwardEnumerator.MoveNext());
+            Assert.AreEqual(openingBar.EndTime, fillForwardEnumerator.Current.EndTime);
+
+            // the clock jumps over 3 hours ahead at once
+            timeProvider.SetCurrentTime(new DateTime(2020, 5, 21, 13, 45, 0));
+
+            // a single fill forward bar is emitted, ending on the data time zone hour grid
+            Assert.IsTrue(fillForwardEnumerator.MoveNext());
+            Assert.IsNotNull(fillForwardEnumerator.Current);
+            Assert.IsTrue(fillForwardEnumerator.Current.IsFillForward);
+            Assert.AreEqual(expectedBarEndTime, fillForwardEnumerator.Current.EndTime);
+            Assert.AreEqual(openingBar.Open, ((TradeBar)fillForwardEnumerator.Current).Open);
+
+            // and nothing else to emit until time moves forward again
+            Assert.IsTrue(fillForwardEnumerator.MoveNext());
+            Assert.IsNull(fillForwardEnumerator.Current);
+
+            enqueueableEnumerator.Dispose();
+        }
+
+        [Test]
+        public void SkipClampsToPreviousSessionCloseWhenMarketIsClosed()
+        {
+            // Thursday, mid session
+            var previousBarEndTime = new DateTime(2020, 5, 21, 15, 30, 0);
+            var timeProvider = new ManualTimeProvider(previousBarEndTime, TimeZones.NewYork);
+            using var fillForwardEnumerator = GetLiveFillForwardEnumerator(timeProvider, previousBarEndTime.Date, Resolution.Minute,
+                out var enqueueableEnumerator, dailyStrictEndTimeEnabled: false);
+            var openingBar = new TradeBar(previousBarEndTime.AddMinutes(-1), Symbols.AAPL, 0.01m, 0.01m, 0.01m, 0.01m, 1, Time.OneMinute);
+
+            enqueueableEnumerator.Enqueue(openingBar);
+            Assert.IsTrue(fillForwardEnumerator.MoveNext());
+            Assert.AreEqual(openingBar.EndTime, fillForwardEnumerator.Current.EndTime);
+
+            // the clock jumps to Saturday noon: the latest expected bar is Friday's last, never a future bar of the next session
+            timeProvider.SetCurrentTime(new DateTime(2020, 5, 23, 12, 0, 0));
+
+            Assert.IsTrue(fillForwardEnumerator.MoveNext());
+            Assert.IsNotNull(fillForwardEnumerator.Current);
+            Assert.IsTrue(fillForwardEnumerator.Current.IsFillForward);
+            Assert.AreEqual(new DateTime(2020, 5, 22, 16, 0, 0), fillForwardEnumerator.Current.EndTime);
+            Assert.AreEqual(openingBar.Open, ((TradeBar)fillForwardEnumerator.Current).Open);
+
+            // next expected bar is the following session open, in the future, nothing to emit
+            Assert.IsTrue(fillForwardEnumerator.MoveNext());
+            Assert.IsNull(fillForwardEnumerator.Current);
+
+            enqueueableEnumerator.Dispose();
+        }
+
+        [Test]
+        public void SkipDoesNotJumpPastNextRealDataPoint()
+        {
+            var previousBarEndTime = new DateTime(2020, 5, 21, 10, 0, 0);
+            var timeProvider = new ManualTimeProvider(previousBarEndTime, TimeZones.NewYork);
+            using var fillForwardEnumerator = GetLiveFillForwardEnumerator(timeProvider, previousBarEndTime.Date, Resolution.Minute,
+                out var enqueueableEnumerator, dailyStrictEndTimeEnabled: false);
+            var openingBar = new TradeBar(previousBarEndTime.AddMinutes(-1), Symbols.AAPL, 0.01m, 0.01m, 0.01m, 0.01m, 1, Time.OneMinute);
+            var nextBar = new TradeBar(previousBarEndTime.AddMinutes(4), Symbols.AAPL, 1m, 2m, 1m, 2m, 100, Time.OneMinute);
+
+            enqueueableEnumerator.Enqueue(openingBar);
+            Assert.IsTrue(fillForwardEnumerator.MoveNext());
+            Assert.AreEqual(openingBar.EndTime, fillForwardEnumerator.Current.EndTime);
+
+            // real data is available behind a stale gap, the clock jumped 30 minutes
+            enqueueableEnumerator.Enqueue(nextBar);
+            timeProvider.SetCurrentTime(previousBarEndTime.AddMinutes(30));
+
+            // fill forward bars never reach past the next real point, which is emitted intact right after
+            var fillForwardCount = 0;
+            while (fillForwardEnumerator.MoveNext() && fillForwardEnumerator.Current != null && fillForwardEnumerator.Current.IsFillForward)
+            {
+                Assert.LessOrEqual(fillForwardEnumerator.Current.EndTime, nextBar.Time.AddMinutes(1));
+                fillForwardCount++;
+                Assert.LessOrEqual(fillForwardCount, 4);
+            }
+            Assert.IsNotNull(fillForwardEnumerator.Current);
+            Assert.IsFalse(fillForwardEnumerator.Current.IsFillForward);
+            Assert.AreEqual(nextBar.EndTime, fillForwardEnumerator.Current.EndTime);
+            Assert.AreEqual(nextBar.Open, ((TradeBar)fillForwardEnumerator.Current).Open);
+
+            enqueueableEnumerator.Dispose();
+        }
+
         private static LiveFillForwardEnumerator GetLiveFillForwardEnumerator(ITimeProvider timeProvider, DateTime startTime, Resolution resolution,
             out EnqueueableEnumerator<BaseData> enqueueableEnumerator, bool dailyStrictEndTimeEnabled, Resolution? ffResolution = null)
         {


### PR DESCRIPTION
## Description

When the live fill forward enumerator falls behind real time — for example at the warmup to live handover, where the frontier jumps by the whole replay duration at once — it back filled the gap bar by bar at the fill forward resolution. With a second resolution subscription present (which drags the fill forward resolution down to one second for every subscription), this meant hundreds of thousands of synthetic bars per subscription, delivered to the algorithm in a single giant time slice: minutes of synchronization thread time on a single time loop and a large memory spike, scaling with subscription count and warmup length.

Now, when the candidate fill forward bar is more than one fill forward period behind real time, the enumerator jumps its reference to the latest expected bar — clamped to the last open session and to the next real data point — and fills forward from there to now. A bounded walk covers what the jump cannot, only ever accepting candidates that are themselves in the past, so session boundaries and delisting semantics are unchanged. Normal live pacing (bar by bar as the clock advances) is unaffected since those candidates are never more than one period stale.

Benchmark, 200 minute subscriptions warming up 7 days with one second resolution subscription and the clock drifting ~6 minutes during the replay: 91.5s → 1.6s wall clock, 45.6M → 71k fill forward points, ~50GB → 1.25GB allocated, and the single catch-up synchronization pass drops from ~30s to ~150ms.

## Related Issue

N/A

## Motivation and Context

Live deployments with warmup and a mixed-resolution universe could spend many minutes inside a single time loop at the end of warmup (risking the isolator limit) while allocating heavily, producing thousands of past-timestamped fill forward bars per subscription that arrive all at once and have no value to the algorithm.

## Requires Documentation Change

No

## How Has This Been Tested?

- New unit tests: a time jump emits only the latest expected bar (minute and second fill forward resolutions), the jump clamps to the previous session close when the market is closed (never emitting a future bar), and it never jumps past the next real data point.
- Existing `LiveFillForwardEnumeratorTests`, `FillForwardEnumeratorTests` and `LiveTradingDataFeedTests` (including delisting event emission) pass locally.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)