### PR TITLE
Fix XSP option minimum price variation

### DIFF
--- a/Common/Securities/IndexOption/IndexOptionSymbolProperties.cs
+++ b/Common/Securities/IndexOption/IndexOptionSymbolProperties.cs
@@ -72,11 +72,17 @@ namespace QuantConnect.Securities.IndexOption
         /// <summary>
         /// Minimum price variation, subject to variability due to contract price
         /// </summary>
-        /// <remarks>https://www.cboe.com/tradable_products/vix/vix_options/specifications/
+        /// <remarks>https://www.cboe.com/tradable_products/sp_500/mini_spx_options/specifications
+        /// https://www.cboe.com/tradable_products/vix/vix_options/specifications/
         /// https://www.cboe.com/tradable_products/sp_500/spx_options/specifications/
         /// https://www.nasdaq.com/docs/2022/08/24/1926-Q22_NDX%20Fact%20Sheet_NAM_v3.pdf</remarks>
         public static decimal MinimumPriceVariationForPrice(Symbol symbol, decimal? referencePrice)
         {
+            if (symbol?.ID.Symbol == "XSP")
+            {
+                return 0.01m;
+            }
+
             if(symbol == null || !referencePrice.HasValue)
             {
                 return 0.05m;

--- a/Tests/Common/Securities/IndexOption/IndexOptionSymbolPropertiesTests.cs
+++ b/Tests/Common/Securities/IndexOption/IndexOptionSymbolPropertiesTests.cs
@@ -1,0 +1,52 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.Securities;
+using QuantConnect.Securities.IndexOption;
+
+namespace QuantConnect.Tests.Common.Securities.IndexOption
+{
+    [TestFixture]
+    public class IndexOptionSymbolPropertiesTests
+    {
+        [TestCase("XSP", 2.99, 0.01)]
+        [TestCase("XSP", 3, 0.01)]
+        [TestCase("XSP", 3.01, 0.01)]
+        [TestCase("SPX", 2.99, 0.05)]
+        [TestCase("SPX", 3, 0.10)]
+        [TestCase("SPX", 3.01, 0.10)]
+        public void MinimumPriceVariationForPrice(string ticker, decimal referencePrice, decimal expected)
+        {
+            var underlying = Symbol.Create(ticker, SecurityType.Index, Market.USA);
+            var option = Symbol.CreateOption(underlying, ticker, Market.USA, OptionStyle.European,
+                OptionRight.Call, 100m, new DateTime(2026, 1, 16));
+
+            Assert.AreEqual(ticker, option.ID.Symbol);
+            Assert.AreEqual(ticker, option.Underlying.ID.Symbol);
+            Assert.AreEqual(expected, IndexOptionSymbolProperties.MinimumPriceVariationForPrice(option, referencePrice));
+        }
+
+        [Test]
+        public void XspMinimumPriceVariationWithoutReferencePrice()
+        {
+            var underlying = Symbol.Create("XSP", SecurityType.Index, Market.USA);
+            var option = Symbol.CreateOption(underlying, "XSP", Market.USA, OptionStyle.European,
+                OptionRight.Call, 100m, new DateTime(2026, 1, 16));
+
+            Assert.AreEqual(0.01m, IndexOptionSymbolProperties.MinimumPriceVariationForPrice(option, null));
+        }
+    }
+}


### PR DESCRIPTION
#### Description

Return a constant `$0.01` minimum price variation for XSP index options instead of applying the SPX `$0.05`/`$0.10` tiers. SPX and the existing VIX/VIXW rules remain unchanged.

The regression tests cover XSP and SPX immediately below, at, and above the `$3.00` boundary, plus XSP before a reference price is available.

#### Related Issue

Fixes #9717

#### Motivation and Context

CBOE specifies a `$0.01` minimum tick for every XSP series. Applying the SPX tiers rounds valid XSP order prices and can change submitted live limit or stop prices.

#### Requires Documentation Change

No. The XML remarks now include the CBOE Mini-SPX specification alongside the existing product references.

#### How Has This Been Tested?

- Built `Common/QuantConnect.csproj` in Release mode with the .NET 10 SDK.
- Ran the focused NUnit fixture in a .NET 10 container: 7/7 tests passed.
- Ran the same fixture against the parent commit: the four XSP cases failed with the old `$0.05`/`$0.10` values while the three SPX cases passed.
- `git diff --check` passed.

The full repository test suite was not run locally and is left to CI.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`