### PR TITLE
feature: keep order tickets in the test order provider

### DIFF
--- a/Tests/Brokerages/BrokerageTests.cs
+++ b/Tests/Brokerages/BrokerageTests.cs
@@ -159,7 +159,7 @@ namespace QuantConnect.Tests.Brokerages
             foreach (var orderEvent in orderEvents)
             {
                 var order = _orderProvider.GetOrderById(orderEvent.OrderId);
-                order.Status = orderEvent.Status;
+                OrderProvider.HandleOrderEvent(orderEvent);
 
                 Log.Trace("");
                 Log.Trace($"ORDER STATUS CHANGED: {orderEvent}, Type: {order.Type}");

--- a/Tests/Brokerages/OrderProvider.cs
+++ b/Tests/Brokerages/OrderProvider.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -32,6 +33,7 @@ namespace QuantConnect.Tests.Brokerages
         private int _groupOrderManagerId;
         private protected readonly IList<Order> _orders;
         private readonly object _lock = new object();
+        private readonly ConcurrentDictionary<int, OrderTicket> _orderTickets = new ConcurrentDictionary<int, OrderTicket>();
 
         public OrderProvider(IList<Order> orders)
         {
@@ -55,6 +57,31 @@ namespace QuantConnect.Tests.Brokerages
             lock (_lock)
             {
                 _orders.Add(order);
+            }
+
+            _orderTickets[order.Id] = CreateOrderTicket(order);
+        }
+
+        /// <summary>
+        /// Applies an order event to the ticket of its order, the way the transaction handler does, so the
+        /// ticket keeps the filled quantity and the average fill price of the order.
+        /// </summary>
+        /// <param name="orderEvent">The order event to apply</param>
+        public void HandleOrderEvent(OrderEvent orderEvent)
+        {
+            var order = GetOrderById(orderEvent.OrderId);
+            if (order == null)
+            {
+                Log.Error($"OrderProvider.HandleOrderEvent(): Lean order id {orderEvent.OrderId} not found");
+                return;
+            }
+
+            order.Status = orderEvent.Status;
+
+            if (_orderTickets.TryGetValue(orderEvent.OrderId, out var orderTicket))
+            {
+                orderEvent.Ticket = orderTicket;
+                orderTicket.AddOrderEvent(orderEvent);
             }
         }
 
@@ -81,17 +108,18 @@ namespace QuantConnect.Tests.Brokerages
 
         public IEnumerable<OrderTicket> GetOrderTickets(Func<OrderTicket, bool> filter = null)
         {
-            throw new NotImplementedException("This method has not been implemented");
+            return _orderTickets.Select(x => x.Value).Where(x => filter == null || filter(x));
         }
 
         public IEnumerable<OrderTicket> GetOpenOrderTickets(Func<OrderTicket, bool> filter = null)
         {
-            throw new NotImplementedException();
+            return GetOrderTickets(x => x.Status.IsOpen() && (filter == null || filter(x)));
         }
 
         public OrderTicket GetOrderTicket(int orderId)
         {
-            throw new NotImplementedException("This method has not been implemented");
+            _orderTickets.TryGetValue(orderId, out var orderTicket);
+            return orderTicket;
         }
 
         public IEnumerable<Order> GetOrders(Func<Order, bool> filter)
@@ -127,6 +155,24 @@ namespace QuantConnect.Tests.Brokerages
         public ProjectedHoldings GetProjectedHoldings(Security security)
         {
             throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Creates the ticket of an order, the way the transaction handler creates it from the request that
+        /// placed the order
+        /// </summary>
+        /// <param name="order">The order to create the ticket for</param>
+        /// <returns>The ticket of the given order</returns>
+        private static OrderTicket CreateOrderTicket(Order order)
+        {
+            var submitRequest = new SubmitOrderRequest(order.Type, order.SecurityType, order.Symbol, order.Quantity, 0m, 0m,
+                order.Time, order.Tag, order.Properties, order.GroupOrderManager);
+            submitRequest.SetOrderId(order.Id);
+
+            var orderTicket = new OrderTicket(null, submitRequest);
+            orderTicket.SetOrder(order);
+
+            return orderTicket;
         }
     }
 }

--- a/Tests/Brokerages/OrderProviderTests.cs
+++ b/Tests/Brokerages/OrderProviderTests.cs
@@ -1,0 +1,105 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using QuantConnect.Orders;
+using QuantConnect.Orders.Fees;
+
+namespace QuantConnect.Tests.Brokerages
+{
+    [TestFixture]
+    public class OrderProviderTests
+    {
+        private static readonly DateTime OrderTime = new DateTime(2024, 1, 3, 15, 0, 0);
+
+        [Test]
+        public void AddedOrderGetsATicket()
+        {
+            var orderProvider = new OrderProvider();
+            var order = new MarketOrder(Symbols.SPY, 10, OrderTime);
+
+            orderProvider.Add(order);
+
+            var orderTicket = orderProvider.GetOrderTicket(order.Id);
+            Assert.That(orderTicket, Is.Not.Null);
+            Assert.That(orderTicket.OrderId, Is.EqualTo(order.Id));
+            Assert.That(orderTicket.Symbol, Is.EqualTo(order.Symbol));
+            Assert.That(orderTicket.Quantity, Is.EqualTo(order.Quantity));
+            Assert.That(orderTicket.QuantityFilled, Is.EqualTo(0m));
+        }
+
+        [Test]
+        public void UnknownOrderHasNoTicket()
+        {
+            Assert.That(new OrderProvider().GetOrderTicket(1), Is.Null);
+        }
+
+        [Test]
+        public void OrderEventKeepsTheFilledQuantityOnTheTicket()
+        {
+            var orderProvider = new OrderProvider();
+            var order = new MarketOrder(Symbols.SPY, 10, OrderTime);
+            orderProvider.Add(order);
+
+            orderProvider.HandleOrderEvent(new OrderEvent(order, OrderTime, OrderFee.Zero)
+            {
+                Status = OrderStatus.PartiallyFilled,
+                FillQuantity = 4,
+                FillPrice = 100m
+            });
+
+            var orderTicket = orderProvider.GetOrderTicket(order.Id);
+            Assert.That(orderTicket.QuantityFilled, Is.EqualTo(4m));
+            Assert.That(orderTicket.QuantityRemaining, Is.EqualTo(6m));
+            Assert.That(order.Status, Is.EqualTo(OrderStatus.PartiallyFilled));
+
+            orderProvider.HandleOrderEvent(new OrderEvent(order, OrderTime, OrderFee.Zero)
+            {
+                Status = OrderStatus.Filled,
+                FillQuantity = 6,
+                FillPrice = 101m
+            });
+
+            Assert.That(orderTicket.QuantityFilled, Is.EqualTo(10m));
+            Assert.That(orderTicket.AverageFillPrice, Is.EqualTo(100.6m));
+            Assert.That(order.Status, Is.EqualTo(OrderStatus.Filled));
+        }
+
+        [Test]
+        public void OpenOrderTicketsSkipTheClosedOrders()
+        {
+            var orderProvider = new OrderProvider();
+            var openOrder = new MarketOrder(Symbols.SPY, 10, OrderTime);
+            var filledOrder = new MarketOrder(Symbols.AAPL, 5, OrderTime);
+            orderProvider.Add(openOrder);
+            orderProvider.Add(filledOrder);
+
+            orderProvider.HandleOrderEvent(new OrderEvent(filledOrder, OrderTime, OrderFee.Zero)
+            {
+                Status = OrderStatus.Filled,
+                FillQuantity = 5,
+                FillPrice = 100m
+            });
+
+            Assert.That(orderProvider.GetOrderTickets().Count(), Is.EqualTo(2));
+
+            var openOrderTickets = orderProvider.GetOpenOrderTickets().ToList();
+            Assert.That(openOrderTickets.Count, Is.EqualTo(1));
+            Assert.That(openOrderTickets[0].OrderId, Is.EqualTo(openOrder.Id));
+        }
+    }
+}


### PR DESCRIPTION
#### Description

`Tests.Brokerages.OrderProvider` threw `NotImplementedException` from `GetOrderTicket`, `GetOrderTickets` and `GetOpenOrderTickets`, so a brokerage that reads a ticket could not be tested with it:

```
System.NotImplementedException: This method has not been implemented
   at QuantConnect.Tests.Brokerages.OrderProvider.GetOrderTicket(Int32 orderId) in Tests\Brokerages\OrderProvider.cs:line 94
```

The provider now creates an `OrderTicket` for every order passed to `Add`, the same way `BrokerageTransactionHandler` creates one from the submit request, and returns it from the three methods. `HandleOrderEvent` applies an order event to the ticket of its order, so `QuantityFilled` and `AverageFillPrice` reflect the fills a test reported:

```csharp
var orderProvider = new OrderProvider();
var order = new MarketOrder(Symbols.SPY, 10, orderTime);
orderProvider.Add(order);

orderProvider.HandleOrderEvent(new OrderEvent(order, orderTime, OrderFee.Zero)
{
    Status = OrderStatus.PartiallyFilled, FillQuantity = 4, FillPrice = 100m
});

orderProvider.GetOrderTicket(order.Id).QuantityFilled;  // 4
```

#### Related PR(s)

N/A

#### Related Issue

N/A

#### Motivation and Context

A brokerage only gets an `IOrderProvider`, and the quantity a Lean order already has filled lives on its ticket. With the test provider throwing, a brokerage that reads `GetOrderTicket(order.Id).QuantityFilled` - for example to skip a fill it has already reported - cannot be covered by an offline test and has to keep its own copy of that number instead. The exception is also swallowed by whatever catches it, so the failure shows up as "no order event was reported" rather than as a missing implementation.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

New fixture `Tests/Brokerages/OrderProviderTests.cs`, 4 tests, all green:

- `AddedOrderGetsATicket` - the ticket carries the order id, symbol and quantity, and starts at zero filled.
- `UnknownOrderHasNoTicket` - `GetOrderTicket` returns `null` instead of throwing.
- `OrderEventKeepsTheFilledQuantityOnTheTicket` - two fills of 4 and 6 at 100 and 101 give `QuantityFilled` 10, `QuantityRemaining` 0 and `AverageFillPrice` 100.6, and the order status follows the events.
- `OpenOrderTicketsSkipTheClosedOrders` - two orders, one filled: `GetOrderTickets` returns both, `GetOpenOrderTickets` returns only the open one.

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
