### PR TITLE
Skip stale chain universe open interest when a newer tick was received

### DIFF
--- a/Algorithm.CSharp/OptionUniverseOpenInterestRegressionAlgorithm.cs
+++ b/Algorithm.CSharp/OptionUniverseOpenInterestRegressionAlgorithm.cs
@@ -86,11 +86,11 @@ namespace QuantConnect.Algorithm.CSharp
                 return;
             }
 
-            // If a more recent open interest tick was received from the data feed, the cache will reflect it instead
+            // If an open interest tick as recent as the chain universe data was received from the data feed, the cache will reflect it instead
             if (checkOpenInterestTick)
             {
                 var lastOpenInterestTick = security.Cache.GetData<OpenInterest>();
-                if (lastOpenInterestTick != null && lastOpenInterestTick.EndTime > chainUniverseData.EndTime)
+                if (lastOpenInterestTick != null && lastOpenInterestTick.EndTime >= chainUniverseData.EndTime)
                 {
                     return;
                 }

--- a/Common/Securities/SecurityCache.cs
+++ b/Common/Securities/SecurityCache.cs
@@ -38,6 +38,7 @@ namespace QuantConnect.Securities
         // this is used to prefer quote bar data over the tradebar data
         private DateTime _lastQuoteBarUpdate;
         private DateTime _lastOHLCUpdate;
+        private DateTime _lastOpenInterestUpdate;
         private BaseData _lastData;
 
         private readonly object _locker = new();
@@ -198,6 +199,7 @@ namespace QuantConnect.Securities
                     StoreDataPoint(data);
                 }
                 OpenInterest = (long)tick.Value;
+                _lastOpenInterestUpdate = tick.EndTime;
 
                 // Update the session with the latest open interest
                 Session?.Update(data);
@@ -325,12 +327,16 @@ namespace QuantConnect.Securities
         /// Helper method to update the open interest cache property from a chain universe data point,
         /// which carries the contracts daily open interest
         /// </summary>
+        /// <remarks>The chain universe data is skipped if a more recent open interest value was already received,
+        /// for example in live trading, where the open interest ticks of the day arrive before the previous
+        /// tradable date's chain universe file is fed into the algorithm</remarks>
         /// <param name="data">The data point being stored</param>
         protected void UpdateOpenInterest(BaseData data)
         {
-            if (data is BaseChainUniverseData chainUniverseData)
+            if (data is BaseChainUniverseData chainUniverseData && chainUniverseData.EndTime >= _lastOpenInterestUpdate)
             {
                 OpenInterest = (long)chainUniverseData.OpenInterest;
+                _lastOpenInterestUpdate = chainUniverseData.EndTime;
             }
         }
 
@@ -455,6 +461,7 @@ namespace QuantConnect.Securities
 
             _lastOHLCUpdate = default;
             _lastQuoteBarUpdate = default;
+            _lastOpenInterestUpdate = default;
             Session?.Reset();
             UnsubscribeToTimeUpdatedEvent();
         }

--- a/Common/Securities/SecurityCache.cs
+++ b/Common/Securities/SecurityCache.cs
@@ -333,7 +333,7 @@ namespace QuantConnect.Securities
         /// <param name="data">The data point being stored</param>
         protected void UpdateOpenInterest(BaseData data)
         {
-            if (data is BaseChainUniverseData chainUniverseData && chainUniverseData.EndTime >= _lastOpenInterestUpdate)
+            if (data is BaseChainUniverseData chainUniverseData && chainUniverseData.EndTime > _lastOpenInterestUpdate)
             {
                 OpenInterest = (long)chainUniverseData.OpenInterest;
                 _lastOpenInterestUpdate = chainUniverseData.EndTime;

--- a/Tests/Common/Securities/SecurityCacheTests.cs
+++ b/Tests/Common/Securities/SecurityCacheTests.cs
@@ -472,6 +472,22 @@ namespace QuantConnect.Tests.Common.Securities
         }
 
         [TestCaseSource(nameof(ChainUniverseOpenInterestCacheTypes))]
+        public void StoreData_ChainUniverseData_DoesNotOverrideOpenInterestTickWithSameEndTime(Type cacheType)
+        {
+            var cache = (SecurityCache)Activator.CreateInstance(cacheType);
+            var universeData = CreateChainUniverseData(cache, new DateTime(2016, 02, 18), 1234);
+
+            // Daily open interest data is stamped at midnight, matching the end time of the previous date's chain universe data
+            var openInterestTick = new OpenInterest(universeData.EndTime, universeData.Symbol, 5000);
+            cache.AddData(openInterestTick);
+            Assert.AreEqual(5000, cache.OpenInterest);
+
+            cache.StoreData(new[] { universeData }, universeData.GetType());
+
+            Assert.AreEqual(5000, cache.OpenInterest);
+        }
+
+        [TestCaseSource(nameof(ChainUniverseOpenInterestCacheTypes))]
         public void StoreData_ChainUniverseData_OverridesOlderOpenInterestTick(Type cacheType)
         {
             var cache = (SecurityCache)Activator.CreateInstance(cacheType);

--- a/Tests/Common/Securities/SecurityCacheTests.cs
+++ b/Tests/Common/Securities/SecurityCacheTests.cs
@@ -26,6 +26,10 @@ using QuantConnect.Data.Market;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Python;
 using QuantConnect.Securities;
+using QuantConnect.Securities.Future;
+using QuantConnect.Securities.FutureOption;
+using QuantConnect.Securities.IndexOption;
+using QuantConnect.Securities.Option;
 using QuantConnect.Tests.Common.Data.Fundamental;
 using QuantConnect.Util;
 
@@ -422,6 +426,121 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(securityCache.BidPrice, 0m);
             Assert.AreEqual(securityCache.AskPrice, 0m);
             Assert.AreEqual(securityCache.Volume, volume);
+        }
+
+        [TestCaseSource(nameof(ChainUniverseOpenInterestCacheTypes))]
+        public void StoreData_ChainUniverseData_SetsOpenInterest(Type cacheType)
+        {
+            var cache = (SecurityCache)Activator.CreateInstance(cacheType);
+            var universeData = CreateChainUniverseData(cache, new DateTime(2016, 02, 18), 1234);
+
+            cache.StoreData(new[] { universeData }, universeData.GetType());
+
+            Assert.AreEqual(1234, cache.OpenInterest);
+            Assert.IsTrue(cache.HasData(universeData.GetType()));
+        }
+
+        [Test]
+        public void StoreData_ChainUniverseData_DoesNotSetOpenInterestOnBaseCache()
+        {
+            var cache = new SecurityCache();
+            var universeData = CreateChainUniverseData(cache, new DateTime(2016, 02, 18), 1234);
+
+            cache.StoreData(new[] { universeData }, universeData.GetType());
+
+            Assert.AreEqual(0, cache.OpenInterest);
+            Assert.IsTrue(cache.HasData(universeData.GetType()));
+        }
+
+        [TestCaseSource(nameof(ChainUniverseOpenInterestCacheTypes))]
+        public void StoreData_ChainUniverseData_DoesNotOverrideNewerOpenInterestTick(Type cacheType)
+        {
+            var cache = (SecurityCache)Activator.CreateInstance(cacheType);
+            var universeData = CreateChainUniverseData(cache, new DateTime(2016, 02, 18), 1234);
+
+            // In live trading the chain universe file of the previous tradable date is fed into the algorithm
+            // after the open interest tick of the day was already received
+            var openInterestTick = new OpenInterest(universeData.EndTime.AddHours(6), universeData.Symbol, 5000);
+            cache.AddDataList(new[] { openInterestTick }, typeof(OpenInterest));
+            Assert.AreEqual(5000, cache.OpenInterest);
+
+            cache.StoreData(new[] { universeData }, universeData.GetType());
+
+            Assert.AreEqual(5000, cache.OpenInterest);
+            // The universe data point is still stored in the cache
+            Assert.IsTrue(cache.HasData(universeData.GetType()));
+        }
+
+        [TestCaseSource(nameof(ChainUniverseOpenInterestCacheTypes))]
+        public void StoreData_ChainUniverseData_OverridesOlderOpenInterestTick(Type cacheType)
+        {
+            var cache = (SecurityCache)Activator.CreateInstance(cacheType);
+            var universeData = CreateChainUniverseData(cache, new DateTime(2016, 02, 18), 1234);
+
+            // In backtesting the chain universe data of the day is emitted at the end of the day,
+            // after the open interest ticks of the day
+            var openInterestTick = new OpenInterest(universeData.EndTime.AddHours(-6), universeData.Symbol, 5000);
+            cache.AddData(openInterestTick);
+            Assert.AreEqual(5000, cache.OpenInterest);
+
+            cache.StoreData(new[] { universeData }, universeData.GetType());
+
+            Assert.AreEqual(1234, cache.OpenInterest);
+        }
+
+        [TestCaseSource(nameof(ChainUniverseOpenInterestCacheTypes))]
+        public void OpenInterestTick_OverridesChainUniverseDataOpenInterest(Type cacheType)
+        {
+            var cache = (SecurityCache)Activator.CreateInstance(cacheType);
+            var date = new DateTime(2016, 02, 18);
+            var universeData = CreateChainUniverseData(cache, date, 1234);
+            cache.StoreData(new[] { universeData }, universeData.GetType());
+            Assert.AreEqual(1234, cache.OpenInterest);
+
+            // A newer open interest tick always overrides the universe open interest
+            var openInterestTick = new OpenInterest(universeData.EndTime.AddHours(6), universeData.Symbol, 5000);
+            cache.AddData(openInterestTick);
+            Assert.AreEqual(5000, cache.OpenInterest);
+
+            // And the next day's universe data is newer than the tick so it overrides it
+            var nextUniverseData = CreateChainUniverseData(cache, date.AddDays(1), 4321);
+            cache.StoreData(new[] { nextUniverseData }, nextUniverseData.GetType());
+            Assert.AreEqual(4321, cache.OpenInterest);
+        }
+
+        [TestCaseSource(nameof(ChainUniverseOpenInterestCacheTypes))]
+        public void Reset_ClearsLastOpenInterestUpdateTime(Type cacheType)
+        {
+            var cache = (SecurityCache)Activator.CreateInstance(cacheType);
+            var universeData = CreateChainUniverseData(cache, new DateTime(2016, 02, 18), 1234);
+            var openInterestTick = new OpenInterest(universeData.EndTime.AddHours(6), universeData.Symbol, 5000);
+            cache.AddData(openInterestTick);
+
+            cache.Reset();
+            Assert.AreEqual(0, cache.OpenInterest);
+
+            cache.StoreData(new[] { universeData }, universeData.GetType());
+
+            Assert.AreEqual(1234, cache.OpenInterest);
+        }
+
+        private static readonly Type[] ChainUniverseOpenInterestCacheTypes =
+        {
+            typeof(OptionCache),
+            typeof(IndexOptionCache),
+            typeof(FutureOptionCache),
+            typeof(FutureCache)
+        };
+
+        private static BaseChainUniverseData CreateChainUniverseData(SecurityCache cache, DateTime date, decimal openInterest)
+        {
+            // open,high,low,close,volume,open_interest
+            var csv = $"100,101,99,100,5000,{openInterest.ToStringInvariant()}";
+            if (cache is FutureCache)
+            {
+                return new FutureUniverse(date, Symbols.Future_ESZ18_Dec2018, csv);
+            }
+            return new OptionUniverse(date, Symbols.SPY_C_192_Feb19_2016, csv);
         }
 
         [Test]


### PR DESCRIPTION
#### Description
Follow up of #9601. `SecurityCache` now tracks the end time of the last open interest update and only sets `OpenInterest` from a chain universe data point (`OptionUniverse`, `FutureUniverse`) when it isn't older than the last open interest tick received. Open interest ticks keep overriding the cache value as before, and `Reset()` clears the tracked time.

#### Motivation and Context
The chain universe data point can reach the security cache after a more recent open interest tick was already received, replacing it with an older value.

#### Requires Documentation Change
None.

#### How Has This Been Tested?
- New `SecurityCacheTests` cases for `OptionCache`, `IndexOptionCache`, `FutureOptionCache` and `FutureCache`: universe data sets the open interest, a newer tick is not overridden, an older tick is, and the value is set again after `Reset()`.
- `OptionUniverseOpenInterestRegressionAlgorithm`, `IndexOptionUniverseOpenInterestRegressionAlgorithm` and `FutureUniverseOpenInterestRegressionAlgorithm` pass unchanged.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
