### PR TITLE
Use the current ticker for the algorithm holdings

### DIFF
--- a/Brokerages/Brokerage.cs
+++ b/Brokerages/Brokerage.cs
@@ -372,13 +372,21 @@ namespace QuantConnect.Brokerages
                 {
                     return new List<Holding>();
                 }
+
+                foreach (var holding in result)
+                {
+                    // the provided ticker might be outdated, the security identifier is the source of truth
+                    holding.Symbol = holding.Symbol.MapToCurrentTicker();
+                }
+
                 Log.Trace($"Brokerage.GetAccountHoldings(): sourcing holdings from provided brokerage data, found {result.Count} entries");
                 return result;
             }
 
             return securities?.Where(security => security.Holdings.AbsoluteQuantity > 0)
-                .OrderBy(security => security.Symbol)
-                .Select(security => new Holding(security)).ToList() ?? new List<Holding>();
+                // the security ticker might be outdated too, it's set when it's created and does not get updated on renames
+                .Select(security => new Holding(security) { Symbol = security.Symbol.MapToCurrentTicker() })
+                .OrderBy(security => security.Symbol).ToList() ?? [];
         }
 
         /// <summary>

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -4503,6 +4503,48 @@ namespace QuantConnect
         }
 
         /// <summary>
+        /// Helper method to get the given symbol using the ticker it's currently mapped to
+        /// </summary>
+        /// <remarks>A symbols ticker is set when it's created and does not get updated if the security is renamed, see <see cref="Symbol.Value"/>,
+        /// this is specially useful for symbols which have been deserialized, since they keep the ticker they were serialized with.
+        /// The <see cref="SecurityIdentifier"/> is the source of truth and never changes</remarks>
+        /// <param name="symbol">The symbol to get the current ticker for</param>
+        /// <returns>The given symbol using the ticker it's currently mapped to, the given symbol if it does not require mapping
+        /// or if the mapping could not be resolved</returns>
+        public static Symbol MapToCurrentTicker(this Symbol symbol)
+        {
+            // covers null and empty symbols
+            if (symbol == null || !symbol.RequiresMapping())
+            {
+                return symbol;
+            }
+
+            try
+            {
+                if (symbol.ID.HasUnderlying && !symbol.HasUnderlying)
+                {
+                    // the deserialized symbol might be missing its underlying, which is required to resolve the mapping
+                    symbol = new Symbol(symbol.ID, symbol.Value);
+                }
+
+                var currentTicker = SecurityIdentifier.Ticker(symbol, DateTime.Today);
+                // for options it's the underlying ticker which gets mapped
+                if (currentTicker != (symbol.HasUnderlying ? symbol.Underlying.Value : symbol.Value))
+                {
+                    Log.Trace($"Extensions.MapToCurrentTicker(): mapping {symbol.Value} to {currentTicker}");
+                    return symbol.UpdateMappedSymbol(currentTicker);
+                }
+            }
+            catch (Exception exception)
+            {
+                // we don't want to fail because of a ticker, the security identifier is what matters
+                Log.Error(exception, $"Failed to map ticker for {symbol.ID}");
+            }
+
+            return symbol;
+        }
+
+        /// <summary>
         /// Checks whether the fill event for closing a trade is a winning trade
         /// </summary>
         /// <param name="fill">The fill event</param>

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -1317,18 +1317,39 @@ namespace QuantConnect.Lean.Engine.Results
         {
             var holdings = new Dictionary<string, Holding>();
 
-            foreach (var security in securities
+            foreach (var holding in securities
                 // If we are invested we send it always, if not, we send non internal, non canonical and tradable securities. When securities are removed they are marked as non tradable.
                 .Where(s => s.Invested || !onlyInvested && (!s.IsInternalFeed() && s.IsTradable && !s.Symbol.IsCanonical()
                     // Continuous futures are different because it's mapped securities are internal and the continuous contract is canonical and non tradable but we want to send them anyways
                     // but we don't want to sent non canonical, non tradable futures, these would be the future chain assets, or continuous mapped contracts that have been removed
                     || s.Symbol.SecurityType == QuantConnect.SecurityType.Future && (s.IsTradable || s.Symbol.IsCanonical() && subscriptionDataConfigService.GetSubscriptionDataConfigs(s.Symbol).Any())))
+                .Select(s => new Holding(s) { Symbol = GetCurrentSymbol(s, subscriptionDataConfigService) })
+                // we order by the ticker we will be sending, which might not be the securities
                 .OrderBy(x => x.Symbol.Value))
             {
-                DictionarySafeAdd(holdings, security.Symbol.ID.ToString(), new Holding(security), "holdings");
+                // the mapping does not change the security identifier
+                DictionarySafeAdd(holdings, holding.Symbol.ID.ToString(), holding, "holdings");
             }
 
             return holdings;
+        }
+
+        /// <summary>
+        /// Helper method to get the security symbol using the ticker it's currently mapped to
+        /// </summary>
+        /// <remarks>A securities symbol ticker is set when it's created and does not get updated if the security is renamed,
+        /// see <see cref="Symbol.Value"/>, but it's subscriptions are, so let's use them as the source of truth.
+        /// Continuous futures are skipped, their mapping is the contract they are currently mapped to, which depends on
+        /// each subscriptions <see cref="SubscriptionDataConfig.ContractDepthOffset"/></remarks>
+        private static Symbol GetCurrentSymbol(Security security, ISubscriptionDataConfigService subscriptionDataConfigService)
+        {
+            var symbol = security.Symbol;
+            if (symbol.SecurityType != QuantConnect.SecurityType.Equity && symbol.SecurityType != QuantConnect.SecurityType.Option)
+            {
+                return symbol;
+            }
+
+            return subscriptionDataConfigService.GetSubscriptionDataConfigs(symbol).FirstOrDefault()?.Symbol ?? symbol;
         }
 
         /// <summary>

--- a/Tests/Brokerages/DefaultBrokerageTests.cs
+++ b/Tests/Brokerages/DefaultBrokerageTests.cs
@@ -19,6 +19,7 @@ using QuantConnect.Orders;
 using QuantConnect.Securities;
 using QuantConnect.Brokerages;
 using System.Collections.Generic;
+using QuantConnect.Securities.Equity;
 
 namespace QuantConnect.Tests.Brokerages
 {
@@ -38,10 +39,94 @@ namespace QuantConnect.Tests.Brokerages
             return TestableBrokerage.GetOrderPositionPublic(direction, holdingsQuantity);
         }
 
+        [TestCase("GOOGL")]
+        [TestCase("GOOG")]
+        [TestCase("SomeOtherTicker")]
+        public void UpdatesOutdatedHoldingsTicker(string ticker)
+        {
+            // GOOGL first ticker is 'GOOG', so it's security identifier holds the outdated ticker
+            var expectedSymbol = Symbol.Create("GOOGL", SecurityType.Equity, Market.USA);
+            var brokerageData = new Dictionary<string, string>
+            {
+                { "live-holdings", $@"[{{""symbol"":{{""id"":""{expectedSymbol.ID}"",""value"":""{ticker}""}},""a"":10,""q"":100}}]" }
+            };
+
+            var holdings = new TestableBrokerage("test").GetAccountHoldingsPublic(brokerageData, null);
+
+            Assert.AreEqual(1, holdings.Count);
+            Assert.AreEqual(expectedSymbol.ID, holdings[0].Symbol.ID);
+            Assert.AreEqual(expectedSymbol.Value, holdings[0].Symbol.Value);
+            Assert.AreEqual(100, holdings[0].Quantity);
+        }
+
+        [Test]
+        public void UpdatesOutdatedOptionHoldingsUnderlyingTicker()
+        {
+            var underlying = Symbol.Create("GOOGL", SecurityType.Equity, Market.USA);
+            var expectedSymbol = Symbol.CreateOption(underlying, Market.USA, OptionStyle.American, OptionRight.Call, 100, new DateTime(2050, 1, 21));
+            // no underlying provided, so it will be created from the security identifier which holds the outdated ticker
+            var brokerageData = new Dictionary<string, string>
+            {
+                { "live-holdings", $@"[{{""symbol"":{{""id"":""{expectedSymbol.ID}"",""value"":""{expectedSymbol.Value}""}},""q"":1}}]" }
+            };
+
+            var holdings = new TestableBrokerage("test").GetAccountHoldingsPublic(brokerageData, null);
+
+            Assert.AreEqual(1, holdings.Count);
+            Assert.AreEqual(expectedSymbol.ID, holdings[0].Symbol.ID);
+            Assert.AreEqual(expectedSymbol.Value, holdings[0].Symbol.Value);
+            Assert.AreEqual(underlying.Value, holdings[0].Symbol.Underlying.Value);
+        }
+
+        [Test]
+        public void DoesNotUpdateTickerForSecuritiesWhichDoNotRequireMapping()
+        {
+            var expectedSymbol = Symbol.Create("EURUSD", SecurityType.Forex, Market.Oanda);
+            var brokerageData = new Dictionary<string, string>
+            {
+                { "live-holdings", $@"[{{""symbol"":{{""id"":""{expectedSymbol.ID}"",""value"":""{expectedSymbol.Value}""}},""q"":1000}}]" }
+            };
+
+            var holdings = new TestableBrokerage("test").GetAccountHoldingsPublic(brokerageData, null);
+
+            Assert.AreEqual(1, holdings.Count);
+            Assert.AreEqual(expectedSymbol, holdings[0].Symbol);
+            Assert.AreEqual(expectedSymbol.Value, holdings[0].Symbol.Value);
+        }
+
+        [Test]
+        public void UpdatesOutdatedSecurityHoldingsTicker()
+        {
+            var expectedSymbol = Symbol.Create("GOOGL", SecurityType.Equity, Market.USA);
+            // the security was created before the rename, so it's ticker is outdated
+            var cashBook = new CashBook();
+            var security = new Equity(new Symbol(expectedSymbol.ID, "GOOG"),
+                SecurityExchangeHours.AlwaysOpen(TimeZones.NewYork),
+                cashBook.Add(Currencies.USD, 0, 1),
+                SymbolProperties.GetDefault(Currencies.USD),
+                cashBook,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache());
+            security.SetLocalTimeKeeper(new TimeKeeper(DateTime.UtcNow, TimeZones.NewYork).GetLocalTimeKeeper(TimeZones.NewYork));
+            security.Holdings.SetHoldings(10, 100);
+
+            var holdings = new TestableBrokerage("test").GetAccountHoldingsPublic(null, new[] { security });
+
+            Assert.AreEqual(1, holdings.Count);
+            Assert.AreEqual(expectedSymbol.ID, holdings[0].Symbol.ID);
+            Assert.AreEqual(expectedSymbol.Value, holdings[0].Symbol.Value);
+            Assert.AreEqual(100, holdings[0].Quantity);
+        }
+
         private class TestableBrokerage : Brokerage
         {
             public TestableBrokerage(string name) : base(name)
             {
+            }
+
+            public List<Holding> GetAccountHoldingsPublic(Dictionary<string, string> brokerageData, IEnumerable<Security> securities)
+            {
+                return GetAccountHoldings(brokerageData, securities);
             }
 
             public override bool IsConnected => throw new NotImplementedException();

--- a/Tests/Engine/Results/LiveTradingResultHandlerTests.cs
+++ b/Tests/Engine/Results/LiveTradingResultHandlerTests.cs
@@ -106,6 +106,46 @@ namespace QuantConnect.Tests.Engine.Results
             Assert.AreEqual(10, holding2.Quantity);
         }
 
+        [Test]
+        public void GetHoldingsUsesCurrentTicker()
+        {
+            var algorithm = new AlgorithmStub();
+            var equity = algorithm.AddEquity("SPY");
+            equity.Holdings.SetHoldings(1, 10);
+
+            // the security gets renamed, it's subscriptions get updated but the security symbol does not
+            foreach (var config in algorithm.SubscriptionManager.SubscriptionDataConfigService.GetSubscriptionDataConfigs(equity.Symbol))
+            {
+                config.MappedSymbol = "NEWSPY";
+            }
+            Assert.AreEqual("SPY", equity.Symbol.Value);
+
+            var result = LiveTradingResultHandler.GetHoldings(algorithm.Securities.Values, algorithm.SubscriptionManager.SubscriptionDataConfigService);
+
+            Assert.IsTrue(result.TryGetValue(equity.Symbol.ID.ToString(), out var holding));
+            Assert.AreEqual(equity.Symbol.ID, holding.Symbol.ID);
+            Assert.AreEqual("NEWSPY", holding.Symbol.Value);
+            Assert.AreEqual(10, holding.Quantity);
+        }
+
+        [Test]
+        public void GetHoldingsAreOrderedByCurrentTicker()
+        {
+            var algorithm = new AlgorithmStub();
+            var aapl = algorithm.AddEquity("AAPL");
+            var spy = algorithm.AddEquity("SPY");
+
+            foreach (var config in algorithm.SubscriptionManager.SubscriptionDataConfigService.GetSubscriptionDataConfigs(aapl.Symbol))
+            {
+                config.MappedSymbol = "ZZZ";
+            }
+
+            var result = LiveTradingResultHandler.GetHoldings(algorithm.Securities.Values, algorithm.SubscriptionManager.SubscriptionDataConfigService);
+
+            // AAPL is now ZZZ so it goes last
+            CollectionAssert.AreEqual(new[] { spy.Symbol.ID.ToString(), aapl.Symbol.ID.ToString() }, result.Keys);
+        }
+
         [TestCase(true)]
         [TestCase(false)]
         public void GetHoldingsNoPosition(bool invested)


### PR DESCRIPTION
## Description

A `Symbol`s ticker is set when it's created and never updated afterwards, but the `SecurityIdentifier` does not change, it holds the first ticker in the map file. This means the ticker we use for holdings can be outdated:

- Symbols deserialized from the `live-holdings` brokerage data keep the ticker they were serialized with, `SymbolJsonConverter` takes the `value` as is. If the security is not already in the algorithm, `GetOrAddUnrequestedSecurity()` re-adds it by ticker, so a wrong ticker ends up creating a different security than the security identifier asks for.
- `Security.Symbol` is get only, so if a security is renamed during a live deployment only its subscriptions get updated, and the holdings we send out keep the old ticker.

This adds the `Symbol.MapToCurrentTicker()` extension method, next to `RequiresMapping()`, which resolves the ticker for the given symbols security identifier and applies it. It's used when sourcing holdings from the provided brokerage data and from the algorithm securities. Symbols which do not require mapping are returned as they are and any failure to resolve the mapping is logged and ignored, the security identifier is what matters.

For the live holdings being sent, `LiveTradingResultHandler.GetHoldings()` now takes the symbol from the securities subscription, which is kept up to date on renames by the data feed, and orders the holdings by the ticker being sent. Continuous futures are skipped there, their subscriptions symbol is the contract they are currently mapped to, which depends on each subscriptions `ContractDepthOffset`.

Note that deserialized option symbols can be missing their underlying, the security identifier has one but `SymbolJsonConverter` leaves the property null when the JSON has no `underlying` node. The mapping is resolved through the underlying, so `MapToCurrentTicker()` restores it before resolving, else the resolve date used is the options expiry and it lands on the wrong map file.

## Related Issue

N/A

## Motivation and Context

Holdings restored from `live-holdings` could be assigned to the wrong security and holdings sent out for renamed securities showed a ticker that no longer exists.

## Requires Documentation Change

N/A

## How Has This Been Tested?

New unit tests in `DefaultBrokerageTests` and `LiveTradingResultHandlerTests` covering the outdated, current and unrelated ticker cases for equities, the option underlying case, securities which do not require mapping, and the holdings ordering.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
