### PR TITLE
Skip paper brokerage dividends during warmup

### DIFF
--- a/Brokerages/Paper/PaperBrokerage.cs
+++ b/Brokerages/Paper/PaperBrokerage.cs
@@ -79,14 +79,17 @@ namespace QuantConnect.Brokerages.Paper
 
                 // apply each dividend directly to the quote cash holdings of the security
                 // this assumes dividends are paid out in a security's quote cash (reasonable assumption)
-                foreach (var dividend in Algorithm.CurrentSlice.Dividends.Values)
+                if (!Algorithm.IsWarmingUp)
                 {
-                    Security security;
-                    if (Algorithm.Securities.TryGetValue(dividend.Symbol, out security))
+                    foreach (var dividend in Algorithm.CurrentSlice.Dividends.Values)
                     {
-                        // compute the total distribution and apply as security's quote currency
-                        var distribution = security.Holdings.Quantity * dividend.Distribution;
-                        security.QuoteCurrency.AddAmount(distribution);
+                        Security security;
+                        if (Algorithm.Securities.TryGetValue(dividend.Symbol, out security))
+                        {
+                            // compute the total distribution and apply as security's quote currency
+                            var distribution = security.Holdings.Quantity * dividend.Distribution;
+                            security.QuoteCurrency.AddAmount(distribution);
+                        }
                     }
                 }
             }

--- a/Tests/Brokerages/Paper/PaperBrokerageTests.cs
+++ b/Tests/Brokerages/Paper/PaperBrokerageTests.cs
@@ -69,6 +69,7 @@ namespace QuantConnect.Tests.Brokerages.Paper
             var slice = new Slice(algorithm.Time, new List<BaseData>(), algorithm.Time);
             slice.Dividends.Add(new Dividend(Symbols.SPY, algorithm.Time, distributionPerShare, 100m));
             algorithm.SetCurrentSlice(slice);
+            algorithm.SetFinishedWarmingUp();
 
             // invoke brokerage
             using var brokerage = new PaperBrokerage(algorithm, null);
@@ -77,6 +78,38 @@ namespace QuantConnect.Tests.Brokerages.Paper
             // verify results
             var postDistributionCash = USD.Amount;
             Assert.AreEqual(preDistributionCash + expectedTotalDistribution, postDistributionCash);
+        }
+
+        [Test]
+        public void DoesNotApplyDividendDistributionDuringWarmup()
+        {
+            // init algorithm
+            var algorithm = new AlgorithmStub(new MockDataFeed());
+            algorithm.AddSecurities(equities: new List<string> { "SPY" });
+            algorithm.SetWarmup(TimeSpan.FromDays(1));
+            algorithm.PostInitialize();
+
+            // init holdings
+            var SPY = algorithm.Securities[Symbols.SPY];
+            SPY.SetMarketPrice(new Tick { Value = 100m });
+            SPY.Holdings.SetHoldings(100m, 1000);
+
+            // resolve expected outcome
+            var USD = algorithm.Portfolio.CashBook[Currencies.USD];
+            var preDistributionCash = USD.Amount;
+            var distributionPerShare = 10m;
+
+            // create slice w/ dividend during warmup
+            var slice = new Slice(algorithm.Time, new List<BaseData>(), algorithm.Time);
+            slice.Dividends.Add(new Dividend(Symbols.SPY, algorithm.Time, distributionPerShare, 100m));
+            algorithm.SetCurrentSlice(slice);
+
+            // invoke brokerage
+            using var brokerage = new PaperBrokerage(algorithm, null);
+            brokerage.Scan();
+
+            // verify results
+            Assert.AreEqual(preDistributionCash, USD.Amount);
         }
 
         [Test]


### PR DESCRIPTION
#### Description
Skip paper-brokerage dividend credits while the algorithm is warming up, and add a regression test for the replayed-dividend case.

#### Related Issue
Fixes #9739

#### Motivation and Context
Warm-up replays historical dividend slices on every paper redeploy. Crediting those slices again permanently inflates the account cash balance.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
- Built the affected test project with .NET 10.
- Ran the two affected PaperBrokerage test methods through an isolated harness; both passed.
- Ran `dotnet format --verify-no-changes` on the changed files.
- The standard NUnit entry point could not run in the container because its global Python initialization crashed inside pythonnet.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`