### PR TITLE
Fix LeanDataReader failing on zips with duplicated entry names

### DIFF
--- a/Compression/Compression.cs
+++ b/Compression/Compression.cs
@@ -204,18 +204,21 @@ namespace QuantConnect
         {
             try
             {
-                using var fs = new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
-                using var archive = new ZipArchive(fs, ZipArchiveMode.Update, leaveOpen: false);
-
-                var existing = archive.GetEntry(entry);
-                if (existing != null)
+                if (!overrideEntry && File.Exists(path))
                 {
-                    if (!overrideEntry)
+                    // check without opening the archive in update mode, disposing an unchanged update archive can rewrite the file
+                    using var readStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None);
+                    using var readArchive = new ZipArchive(readStream, ZipArchiveMode.Read, leaveOpen: false);
+                    if (readArchive.GetEntry(entry) != null)
                     {
                         return false;
                     }
-                    existing.Delete();
                 }
+
+                using var fs = new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+                using var archive = new ZipArchive(fs, ZipArchiveMode.Update, leaveOpen: false);
+
+                archive.GetEntry(entry)?.Delete();
 
                 var zipEntry = archive.CreateEntry(entry, CompressionLevel.Optimal);
 
@@ -703,11 +706,11 @@ namespace QuantConnect
         /// a key of the zip entry name and the value of the zip entry's file lines</returns>
         public static IEnumerable<KeyValuePair<string, List<string>>> Unzip(Stream stream)
         {
-            using (var zip = ZipFile.Read(stream))
+            using (var zip = new ZipArchive(stream, ZipArchiveMode.Read))
             {
-                foreach (var entry in zip)
+                foreach (var entry in zip.Entries)
                 {
-                    yield return new KeyValuePair<string, List<string>>(entry.FileName, ReadZipEntry(entry));
+                    yield return new KeyValuePair<string, List<string>>(entry.FullName, ReadZipEntry(entry));
                 }
             }
         }
@@ -738,12 +741,11 @@ namespace QuantConnect
 
         private static IEnumerable<KeyValuePair<string, List<string>>> ReadLinesImpl(string filename, bool firstEntryOnly = false)
         {
-            using (var zip = ZipFile.Read(filename))
+            using (var zip = new ZipArchive(File.OpenRead(filename), ZipArchiveMode.Read))
             {
-                for (var i = 0; i < zip.Count; i++)
+                foreach (var entry in zip.Entries)
                 {
-                    var entry = zip[i];
-                    yield return new KeyValuePair<string, List<string>>(entry.FileName, ReadZipEntry(entry));
+                    yield return new KeyValuePair<string, List<string>>(entry.FullName, ReadZipEntry(entry));
                     if (firstEntryOnly)
                     {
                         yield break;
@@ -752,10 +754,10 @@ namespace QuantConnect
             }
         }
 
-        private static List<string> ReadZipEntry(Ionic.Zip.ZipEntry entry)
+        private static List<string> ReadZipEntry(ZipArchiveEntry entry)
         {
             var result = new List<string>();
-            using var entryReader = new StreamReader(entry.OpenReader());
+            using var entryReader = new StreamReader(entry.Open());
             var line = entryReader.ReadLine();
             while (line != null)
             {

--- a/Tests/ToolBox/LeanDataReaderTests.cs
+++ b/Tests/ToolBox/LeanDataReaderTests.cs
@@ -573,5 +573,41 @@ namespace QuantConnect.Tests.ToolBox
             }
         }
 
+
+        [Test]
+        public void ReadsZipWithDuplicatedEntries()
+        {
+            // legacy zips written with DotNetZip for unicode symbols contain the same (mangled) entry name multiple times,
+            // DotNetZip's reader renames duplicates through a process wide counter which overflows after 25 calls
+            var symbol = Symbol.Create("币安人生usdc", SecurityType.Crypto, Market.Binance);
+            var directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var filePath = LeanData.GenerateZipFilePath(directory, symbol, DateTime.UtcNow, Resolution.Daily, TickType.Trade);
+            Directory.CreateDirectory(Path.GetDirectoryName(filePath));
+            try
+            {
+                using (var archive = System.IO.Compression.ZipFile.Open(filePath, System.IO.Compression.ZipArchiveMode.Create))
+                {
+                    for (var i = 0; i < 30; i++)
+                    {
+                        var entry = archive.CreateEntry("????usdc.csv");
+                        using var writer = new StreamWriter(entry.Open());
+                        // the last entry is the most recent one and holds the complete data
+                        for (var j = 0; j <= i; j++)
+                        {
+                            writer.WriteLine($"2024010{j % 9 + 1} 00:00,1,2,0.5,1.5,100");
+                        }
+                    }
+                }
+
+                var data = new LeanDataReader(filePath).Parse().ToList();
+
+                Assert.AreEqual(30, data.Count);
+                Assert.IsTrue(data.All(x => x.Symbol == symbol && x is TradeBar));
+            }
+            finally
+            {
+                Directory.Delete(directory, true);
+            }
+        }
     }
 }

--- a/Tests/ToolBox/LeanDataReaderTests.cs
+++ b/Tests/ToolBox/LeanDataReaderTests.cs
@@ -577,7 +577,7 @@ namespace QuantConnect.Tests.ToolBox
         [Test]
         public void ReadsZipWithDuplicatedEntries()
         {
-            // legacy zips written with DotNetZip for unicode symbols contain the same (mangled) entry name multiple times,
+            // legacy zips written with DotNetZip for unicode symbols can contain the same (mangled) entry name multiple times,
             // DotNetZip's reader renames duplicates through a process wide counter which overflows after 25 calls
             var symbol = Symbol.Create("币安人生usdc", SecurityType.Crypto, Market.Binance);
             var directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
@@ -591,11 +591,7 @@ namespace QuantConnect.Tests.ToolBox
                     {
                         var entry = archive.CreateEntry("????usdc.csv");
                         using var writer = new StreamWriter(entry.Open());
-                        // the last entry is the most recent one and holds the complete data
-                        for (var j = 0; j <= i; j++)
-                        {
-                            writer.WriteLine($"2024010{j % 9 + 1} 00:00,1,2,0.5,1.5,100");
-                        }
+                        writer.WriteLine($"2024010{i % 9 + 1} 00:00,1,2,0.5,1.5,100");
                     }
                 }
 

--- a/ToolBox/LeanDataReader.cs
+++ b/ToolBox/LeanDataReader.cs
@@ -16,8 +16,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
-using Ionic.Zip;
 using NodaTime;
 using QuantConnect.Data;
 using QuantConnect.Logging;
@@ -115,20 +115,26 @@ namespace QuantConnect.ToolBox
             }
 
             var factory = (BaseData) ObjectActivator.GetActivator(_config.Type).Invoke(new object[0]);
+            var implementsStreamReader = _config.Type.ImplementsStreamReader();
+            // for futures and options if no entry was provided we just read all
+            var readSymbolFromEntry = _zipentry == null && (_config.SecurityType == SecurityType.Future || _config.SecurityType.IsOption());
 
-            if (_config.Type.ImplementsStreamReader())
+            using (var zip = new ZipArchive(File.OpenRead(_zipPath), ZipArchiveMode.Read))
             {
-                using (var zip = new ZipFile(_zipPath))
+                // legacy zips could contain the same entry name multiple times, the last one is the most recent one
+                var entries = zip.Entries
+                    .Where(x => _zipentry == null || string.Equals(x.FullName, _zipentry, StringComparison.OrdinalIgnoreCase))
+                    .GroupBy(x => x.FullName, StringComparer.OrdinalIgnoreCase)
+                    .Select(x => x.Last());
+                foreach (var zipEntry in entries)
                 {
-                    foreach (var zipEntry in zip.Where(x => _zipentry == null || string.Equals(x.FileName, _zipentry, StringComparison.OrdinalIgnoreCase)))
+                    // we get the contract symbol from the zip entry if not already provided with the zip entry
+                    var symbol = readSymbolFromEntry
+                        ? LeanData.ReadSymbolFromZipEntry(_config.Symbol, _config.Resolution, zipEntry.FullName)
+                        : _config.Symbol;
+                    using (var entryReader = new StreamReader(zipEntry.Open()))
                     {
-                        // we get the contract symbol from the zip entry if not already provided with the zip entry
-                        var symbol = _config.Symbol;
-                        if(_zipentry == null && (_config.SecurityType == SecurityType.Future || _config.SecurityType.IsOption()))
-                        {
-                            symbol = LeanData.ReadSymbolFromZipEntry(_config.Symbol, _config.Resolution, zipEntry.FileName);
-                        }
-                        using (var entryReader = new StreamReader(zipEntry.OpenReader()))
+                        if (implementsStreamReader)
                         {
                             while (!entryReader.EndOfStream)
                             {
@@ -137,38 +143,18 @@ namespace QuantConnect.ToolBox
                                 yield return dataPoint;
                             }
                         }
+                        else
+                        {
+                            string line;
+                            while ((line = entryReader.ReadLine()) != null)
+                            {
+                                var dataPoint = factory.Reader(_config, line, _date, false);
+                                dataPoint.Symbol = symbol;
+                                yield return dataPoint;
+                            }
+                        }
                     }
                 }
-            }
-            // for futures and options if no entry was provided we just read all
-            else if (_zipentry == null && (_config.SecurityType == SecurityType.Future || _config.SecurityType.IsOption()))
-            {
-                foreach (var entries in Compression.Unzip(_zipPath))
-                {
-                    // we get the contract symbol from the zip entry
-                    var symbol = LeanData.ReadSymbolFromZipEntry(_config.Symbol, _config.Resolution, entries.Key);
-                    foreach (var line in entries.Value)
-                    {
-                        var dataPoint = factory.Reader(_config, line, _date, false);
-                        dataPoint.Symbol = symbol;
-                        yield return dataPoint;
-                    }
-                }
-            }
-            else
-            {
-                ZipFile zipFile;
-                using (var unzipped = Compression.Unzip(_zipPath, _zipentry, out zipFile))
-                {
-                    if (unzipped == null)
-                        yield break;
-                    string line;
-                    while ((line = unzipped.ReadLine()) != null)
-                    {
-                        yield return factory.Reader(_config, line, _date, false);
-                    }
-                }
-                zipFile.Dispose();
             }
         }
 

--- a/ToolBox/LeanDataReader.cs
+++ b/ToolBox/LeanDataReader.cs
@@ -115,26 +115,17 @@ namespace QuantConnect.ToolBox
             }
 
             var factory = (BaseData) ObjectActivator.GetActivator(_config.Type).Invoke(new object[0]);
-            var implementsStreamReader = _config.Type.ImplementsStreamReader();
-            // for futures and options if no entry was provided we just read all
+            // for futures and options if no entry was provided we get the contract symbol from the zip entry
             var readSymbolFromEntry = _zipentry == null && (_config.SecurityType == SecurityType.Future || _config.SecurityType.IsOption());
 
-            using (var zip = new ZipArchive(File.OpenRead(_zipPath), ZipArchiveMode.Read))
+            if (_config.Type.ImplementsStreamReader())
             {
-                // legacy zips could contain the same entry name multiple times, the last one is the most recent one
-                var entries = zip.Entries
-                    .Where(x => _zipentry == null || string.Equals(x.FullName, _zipentry, StringComparison.OrdinalIgnoreCase))
-                    .GroupBy(x => x.FullName, StringComparer.OrdinalIgnoreCase)
-                    .Select(x => x.Last());
-                foreach (var zipEntry in entries)
+                using (var zip = new ZipArchive(File.OpenRead(_zipPath), ZipArchiveMode.Read))
                 {
-                    // we get the contract symbol from the zip entry if not already provided with the zip entry
-                    var symbol = readSymbolFromEntry
-                        ? LeanData.ReadSymbolFromZipEntry(_config.Symbol, _config.Resolution, zipEntry.FullName)
-                        : _config.Symbol;
-                    using (var entryReader = new StreamReader(zipEntry.Open()))
+                    foreach (var zipEntry in zip.Entries.Where(x => _zipentry == null || string.Equals(x.FullName, _zipentry, StringComparison.OrdinalIgnoreCase)))
                     {
-                        if (implementsStreamReader)
+                        var symbol = readSymbolFromEntry ? LeanData.ReadSymbolFromZipEntry(_config.Symbol, _config.Resolution, zipEntry.FullName) : _config.Symbol;
+                        using (var entryReader = new StreamReader(zipEntry.Open()))
                         {
                             while (!entryReader.EndOfStream)
                             {
@@ -143,16 +134,19 @@ namespace QuantConnect.ToolBox
                                 yield return dataPoint;
                             }
                         }
-                        else
-                        {
-                            string line;
-                            while ((line = entryReader.ReadLine()) != null)
-                            {
-                                var dataPoint = factory.Reader(_config, line, _date, false);
-                                dataPoint.Symbol = symbol;
-                                yield return dataPoint;
-                            }
-                        }
+                    }
+                }
+            }
+            else
+            {
+                foreach (var entry in Compression.Unzip(_zipPath).Where(x => _zipentry == null || string.Equals(x.Key, _zipentry, StringComparison.OrdinalIgnoreCase)))
+                {
+                    var symbol = readSymbolFromEntry ? LeanData.ReadSymbolFromZipEntry(_config.Symbol, _config.Resolution, entry.Key) : _config.Symbol;
+                    foreach (var line in entry.Value)
+                    {
+                        var dataPoint = factory.Reader(_config, line, _date, false);
+                        dataPoint.Symbol = symbol;
+                        yield return dataPoint;
                     }
                 }
             }


### PR DESCRIPTION
## Description

Legacy zip files for unicode symbols (e.g. `币安人生usdc_trade.zip`) contain the same, IBM437 mangled, entry name multiple times: before #9244 DotNetZip mangled the entry name on write and `ContainsEntry` never matched, so every daily append added a new duplicated entry.

DotNetZip's reader renames duplicated entries through `CopyHelper.AppendCopyToFileName`, which uses a process wide static counter that throws `OverflowException: overflow while creating filename` after 25 calls, failing the crypto coarse universe data converter:

```
Ionic.Zip.ZipException: Could not read /Data/crypto/binance/daily/币安人生usdc_trade.zip as a zip file
 ---> System.OverflowException: overflow while creating filename
   at Ionic.Zip.ZipEntry.CopyHelper.AppendCopyToFileName(String f)
   at Ionic.Zip.ZipEntry.ReadDirEntry(ZipFile zf, Dictionary`2 previouslySeen)
   ...
   at QuantConnect.ToolBox.LeanDataReader.Parse()+MoveNext()
```

Changes:
- `LeanDataReader.Parse()` and `Compression.Unzip`/`ReadLines` use `System.IO.Compression.ZipArchive`. Duplicated entries are read as is (affected legacy daily/hour files are being reaggregated on the data side).
- `Compression.ZipCreateAppendData`: when the entry already exists and we are not overriding it, check in read mode instead of update mode. Disposing an unchanged update mode `ZipArchive` over a zip64 archive truncates the file (reproduced on net10), DotNetZip's local header scan fallback was hiding it.
- Regression test `ReadsZipWithDuplicatedEntries`, fails on master with the exception above.

No public contracts changed.

## Related Issue

Follow up of #9244

## Motivation and Context

Crypto coarse universe converter failing for binance.

## Requires Documentation Change

No

## How Has This Been Tested?

New regression test plus ToolBox, Compression, data cache provider and LeanDataWriter tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance improvement (non-breaking change which improves performance)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Non-functional change (xml comments/documentation/etc)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<title>` or `feature-<issue#>-<title>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEFD7hdkrt49KvNjr9ehCd