### PR TITLE
Let TerminalLink route orders on tradable and CFD-booked indices

### DIFF
--- a/Common/Brokerages/TerminalLinkBrokerageModel.cs
+++ b/Common/Brokerages/TerminalLinkBrokerageModel.cs
@@ -57,7 +57,19 @@ namespace QuantConnect.Brokerages
         /// <param name="message">If this function returns false, a brokerage message detailing why the order may not be submitted</param>
         public override bool CanSubmitOrder(Security security, Order order, out BrokerageMessageEvent message)
         {
-            if (!_supportedSecurityTypes.Contains(security.Type))
+            if (security.Type == SecurityType.Index)
+            {
+                // Index securities are data-only on EMSX by default. They are routable when the algorithm opts in by
+                // marking the security tradable, or when the ticket is booked as a CFD/swap: a custom basket whose
+                // market data is delivered as an index is routed by typing the index ticker into the EMSX security field.
+                if (!security.IsTradable && order.Properties is not TerminalLinkOrderProperties { IsCfdTrade: true })
+                {
+                    message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
+                        Messages.TerminalLinkBrokerageModel.UntradableIndexSecurity(security));
+                    return false;
+                }
+            }
+            else if (!_supportedSecurityTypes.Contains(security.Type))
             {
                 message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
                     Messages.DefaultBrokerageModel.UnsupportedSecurityType(this, security));

--- a/Common/Messages/Messages.Brokerages.cs
+++ b/Common/Messages/Messages.Brokerages.cs
@@ -581,6 +581,24 @@ namespace QuantConnect
         }
 
         /// <summary>
+        /// Provides user-facing messages for the <see cref="Brokerages.TerminalLinkBrokerageModel"/> class and its consumers or related classes
+        /// </summary>
+        public static class TerminalLinkBrokerageModel
+        {
+            /// <summary>
+            /// Returns a message saying an Index order was rejected because the security was not marked as tradable
+            /// and the ticket was not booked as a CFD trade
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static string UntradableIndexSecurity(Securities.Security security)
+            {
+                return Invariant($@"The TerminalLinkBrokerageModel treats the {security.Type} security type as data-only. To route {
+                    security.Symbol.Value} through EMSX, set Securities[{security.Symbol.Value
+                    }].IsTradable to true, or set TerminalLinkOrderProperties.IsCfdTrade to true to book the ticket as a CFD/swap.");
+            }
+        }
+
+        /// <summary>
         /// Provides user-facing messages for the <see cref="Brokerages.WolverineBrokerageModel"/> class and its consumers or related classes
         /// </summary>
         public static class WolverineBrokerageModel

--- a/Tests/Common/Brokerages/TerminalLinkBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/TerminalLinkBrokerageModelTests.cs
@@ -41,17 +41,71 @@ namespace QuantConnect.Tests.Common.Brokerages
             Assert.IsNull(message);
         }
 
-        // Index is data-only on TerminalLink; Forex/Crypto/Cfd and FutureOption
-        // are not supported for trading.
+        // Forex/Crypto/Cfd and FutureOption are not supported for trading.
         [TestCase("EURUSD", SecurityType.Forex)]
         [TestCase("BTCUSD", SecurityType.Crypto)]
         [TestCase("DE10YBEUR", SecurityType.Cfd)]
-        [TestCase("SPX", SecurityType.Index)]
         public void CannotSubmitOrder_ForUnsupportedSecurityTypes(string ticker, SecurityType securityType)
         {
             var algo = new AlgorithmStub();
             var security = algo.AddSecurity(securityType, ticker);
             var order = new MarketOrder(security.Symbol, 1, new DateTime(2024, 1, 2));
+
+            Assert.IsFalse(_brokerageModel.CanSubmitOrder(security, order, out var message));
+            Assert.AreEqual(BrokerageMessageType.Warning, message.Type);
+            Assert.AreEqual("NotSupported", message.Code);
+        }
+
+        // A custom basket whose market data arrives as an index is booked on EMSX as a CFD/swap,
+        // so the CFD flag makes an Index order routable even if the security was left data-only.
+        [Test]
+        public void CanSubmitOrder_ForIndex_WhenBookedAsCfdTrade()
+        {
+            var algo = new AlgorithmStub();
+            var security = algo.AddSecurity(SecurityType.Index, "SPX");
+            var properties = new TerminalLinkOrderProperties { IsCfdTrade = true };
+            var order = new MarketOrder(security.Symbol, 1, new DateTime(2024, 1, 2), properties: properties);
+
+            Assert.IsFalse(security.IsTradable);
+            Assert.IsTrue(_brokerageModel.CanSubmitOrder(security, order, out var message), message?.Message);
+            Assert.IsNull(message);
+        }
+
+        // Marking the index tradable is the other way in, and it does not require TerminalLink order properties.
+        [Test]
+        public void CanSubmitOrder_ForIndex_WhenMarkedTradable()
+        {
+            var algo = new AlgorithmStub();
+            var security = algo.AddSecurity(SecurityType.Index, "SPX");
+            security.IsTradable = true;
+            var order = new MarketOrder(security.Symbol, 1, new DateTime(2024, 1, 2));
+
+            Assert.IsTrue(_brokerageModel.CanSubmitOrder(security, order, out var message), message?.Message);
+            Assert.IsNull(message);
+        }
+
+        [Test]
+        public void CannotSubmitOrder_ForDataOnlyIndex([Values] bool terminalLinkProperties)
+        {
+            var algo = new AlgorithmStub();
+            var security = algo.AddSecurity(SecurityType.Index, "SPX");
+            var properties = terminalLinkProperties ? new TerminalLinkOrderProperties() : new OrderProperties();
+            var order = new MarketOrder(security.Symbol, 1, new DateTime(2024, 1, 2), properties: properties);
+
+            Assert.IsFalse(security.IsTradable);
+            Assert.IsFalse(_brokerageModel.CanSubmitOrder(security, order, out var message));
+            Assert.AreEqual(BrokerageMessageType.Warning, message.Type);
+            Assert.AreEqual("NotSupported", message.Code);
+        }
+
+        // The CFD flag lifts the security type restriction only; the order type restriction still applies.
+        [Test]
+        public void CannotSubmitOrder_ForIndexCfdTrade_WithUnsupportedOrderType()
+        {
+            var algo = new AlgorithmStub();
+            var security = algo.AddSecurity(SecurityType.Index, "SPX");
+            var properties = new TerminalLinkOrderProperties { IsCfdTrade = true };
+            var order = new MarketOnCloseOrder(security.Symbol, 1, new DateTime(2024, 1, 2), properties: properties);
 
             Assert.IsFalse(_brokerageModel.CanSubmitOrder(security, order, out var message));
             Assert.AreEqual(BrokerageMessageType.Warning, message.Type);


### PR DESCRIPTION
## Description

`TerminalLinkBrokerageModel.CanSubmitOrder` rejected every `SecurityType.Index` order, which blocked a supported Bloomberg EMSX workflow: booking a custom basket (e.g. a Morgan Stanley basket swap) whose market data arrives through B-Pipe as an index, by typing the index ticker into the EMSX security field and routing the ticket as a CFD/swap. `TerminalLinkBrokerage.PlaceOrder` already sends `EMSX_CFD_FLAG` for those orders and `TerminalLinkSymbolMapper` already resolves index tickers, so the engine-level pre-flight check was the only thing in the way.

Indices stay data-only by default. An `Index` order is now accepted when either:

- the algorithm opts in through the existing `Security.IsTradable` flag (LEAN's established way to make an index tradable, see `Extensions.MakeTradable` / `Index.ManualSetIsTradable`), or
- the ticket carries `TerminalLinkOrderProperties.IsCfdTrade`, which is an order-level flag independent of the security type by design.

Everything downstream is unchanged: the supported order type check and `DefaultBrokerageModel.CanSubmitOrder` still run for index orders, so an index CFD ticket with e.g. a `MarketOnClose` order is still rejected. The rejection message for a data-only index now names both ways in instead of the generic "does not support Index security type".

Closes #9747

## Related Issue

Closes #9747

## Motivation and Context

Reported by a live Institution user whose order was invalidated with `BrokerageModel declared unable to submit order: ... The TerminalLinkBrokerageModel does not support Index security type.` even though the order was explicitly flagged `IsCfdTrade = true`. In a standard (non-LEAN) EMSX ticket this booking flow is normal and supported.

## Requires Documentation Change

No.

## How Has This Been Tested?

`TerminalLinkBrokerageModelTests` — 21 tests pass. The `SPX`/`SecurityType.Index` case was removed from `CannotSubmitOrder_ForUnsupportedSecurityTypes` and replaced by four cases:

- `CanSubmitOrder_ForIndex_WhenBookedAsCfdTrade` — data-only index + `IsCfdTrade` is accepted
- `CanSubmitOrder_ForIndex_WhenMarkedTradable` — `IsTradable = true` is accepted without TerminalLink order properties
- `CannotSubmitOrder_ForDataOnlyIndex` — still rejected with plain `OrderProperties` and with `TerminalLinkOrderProperties` that do not set the flag
- `CannotSubmitOrder_ForIndexCfdTrade_WithUnsupportedOrderType` — the CFD flag lifts the security type restriction only

The surrounding brokerage model and `TerminalLinkOrderProperties` suites also pass (816 tests).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
