### PR TITLE
Validate option underlying subscription resolution

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -2454,6 +2454,14 @@ namespace QuantConnect.Algorithm
                 }
             }
 
+            var optionResolution = resolution ?? UniverseSettings.Resolution;
+            var underlyingResolution = underlyingConfigs.GetHighestResolution();
+            if (underlyingResolution > optionResolution)
+            {
+                throw new ArgumentException(Messages.QCAlgorithm.AddOptionContractUnderlyingResolution(
+                    symbol, optionResolution, underlying, underlyingResolution));
+            }
+
             var configs = SubscriptionManager.SubscriptionDataConfigService.Add(symbol, resolution, fillForward, extendedMarketHours,
                 dataNormalizationMode: DataNormalizationMode.Raw);
             var option = (Option)Securities.CreateSecurity(symbol, configs, leverage, underlying: underlyingSecurity);

--- a/Common/Messages/Messages.Algorithm.cs
+++ b/Common/Messages/Messages.Algorithm.cs
@@ -99,6 +99,18 @@ namespace QuantConnect
                 return $"{AlgorithmPrefix()}.{FormatCode("AddData")}(): the first argument must be a custom data type (a Python class deriving from {FormatCode("PythonData")} or a CLR {FormatCode("BaseData")} type), but received {repr}. " +
                     $"To subscribe to built-in asset classes use, for example, {FormatCode("AddEquity")} or {FormatCode("AddCrypto")}.";
             }
+
+            /// <summary>
+            /// Returns a string message saying an option cannot use a finer resolution than its underlying
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static string AddOptionContractUnderlyingResolution(global::QuantConnect.Symbol option, Resolution optionResolution,
+                global::QuantConnect.Symbol underlying, Resolution underlyingResolution)
+            {
+                return $"{AlgorithmPrefix()}.{FormatCode("AddOptionContract")}(): option contract {option} uses {optionResolution} resolution, " +
+                    $"which is finer than its underlying {underlying} subscription at {underlyingResolution} resolution. " +
+                    $"Add the underlying at {optionResolution} resolution or finer before adding the option contract so its implied volatility and Greeks use a current underlying price.";
+            }
         }
 
         /// <summary>

--- a/Tests/Algorithm/AlgorithmAddDataTests.cs
+++ b/Tests/Algorithm/AlgorithmAddDataTests.cs
@@ -724,6 +724,54 @@ namespace QuantConnect.Tests.Algorithm
             Assert.IsTrue(exception.Message.Contains("is delisted"), $"Unexpected exception message: {exception.Message}");
         }
 
+        [TestCase(Resolution.Daily, Resolution.Minute, true)]
+        [TestCase(Resolution.Hour, Resolution.Minute, true)]
+        [TestCase(Resolution.Minute, Resolution.Minute, false)]
+        [TestCase(Resolution.Second, Resolution.Minute, false)]
+        public void AddOptionContractValidatesUnderlyingResolution(
+            Resolution underlyingResolution, Resolution optionResolution, bool shouldThrow)
+        {
+            var algorithm = Algorithm();
+            var underlying = algorithm.AddEquity("SPY", underlyingResolution).Symbol;
+            var option = Symbol.CreateOption(underlying, Market.USA, OptionStyle.American, OptionRight.Call,
+                100m, new DateTime(2027, 1, 15));
+
+            if (shouldThrow)
+            {
+                var exception = Assert.Throws<ArgumentException>(() => algorithm.AddOptionContract(option, optionResolution));
+                StringAssert.Contains("finer than its underlying", exception.Message);
+                StringAssert.Contains($"Add the underlying at {optionResolution} resolution or finer", exception.Message);
+            }
+            else
+            {
+                Assert.DoesNotThrow(() => algorithm.AddOptionContract(option, optionResolution));
+            }
+        }
+
+        [Test]
+        public void AddOptionContractUsesHighestAvailableUnderlyingResolution()
+        {
+            var algorithm = Algorithm();
+            var underlying = algorithm.AddEquity("SPY", Resolution.Daily).Symbol;
+            algorithm.AddEquity("SPY", Resolution.Minute);
+            var option = Symbol.CreateOption(underlying, Market.USA, OptionStyle.American, OptionRight.Call,
+                100m, new DateTime(2027, 1, 15));
+
+            Assert.DoesNotThrow(() => algorithm.AddOptionContract(option, Resolution.Minute));
+        }
+
+        [Test]
+        public void AddOptionContractValidatesUnderlyingResolutionFromUniverseSettings()
+        {
+            var algorithm = Algorithm();
+            algorithm.UniverseSettings.Resolution = Resolution.Minute;
+            var underlying = algorithm.AddEquity("SPY", Resolution.Daily).Symbol;
+            var option = Symbol.CreateOption(underlying, Market.USA, OptionStyle.American, OptionRight.Call,
+                100m, new DateTime(2027, 1, 15));
+
+            Assert.Throws<ArgumentException>(() => algorithm.AddOptionContract(option));
+        }
+
         private static SubscriptionDataConfig GetMatchingSubscription(QCAlgorithm algorithm, Symbol symbol, Type type)
         {
             // find a subscription matchin the requested type with a higher resolution than requested


### PR DESCRIPTION
#### Description

Validate an option contract's effective resolution before adding its subscription. If the finest existing underlying subscription is coarser than the option contract resolution, `AddOptionContract` now throws an `ArgumentException` with guidance to add the underlying at the same or a finer resolution.

The validation uses the finest available underlying subscription, so algorithms with multiple underlying subscriptions continue to work when any subscription is sufficiently fine. It also uses `UniverseSettings.Resolution` when the option resolution argument is omitted.

#### Related Issue

Closes #9732.

#### Motivation and Context

LEAN computes option implied volatility and Greeks from the underlying's latest price. Previously, a minute option subscription could silently use a stale daily underlying price for the entire session. Failing fast prevents silently incorrect analytics without introducing a hidden subscription or changing data costs.

#### Requires Documentation Change

No. The exception explains the required subscription relationship.

#### How Has This Been Tested?

- Built `Tests/QuantConnect.Tests.csproj` in Release mode with .NET 10: 0 errors.
- Ran the six new resolution-validation cases in a .NET 10 + Python runtime container: 6 passed, 0 failed.
- Ran the complete `AlgorithmAddDataTests` fixture in the same minimal container: 54 passed. The only two failures were existing Python/Pandas tests because the minimal container intentionally does not include pandas; neither test exercises this change. Upstream CI uses the full `quantconnect/lean:foundation` environment.
- Ran `git diff --check` successfully.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed. (All new tests pass; two unrelated existing Python/Pandas tests require the upstream foundation image.)
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
