### PR TITLE
Let TerminalLink submit orders on index securities

### DIFF
--- a/Common/Brokerages/TerminalLinkBrokerageModel.cs
+++ b/Common/Brokerages/TerminalLinkBrokerageModel.cs
@@ -30,6 +30,7 @@ namespace QuantConnect.Brokerages
             SecurityType.Option,
             SecurityType.IndexOption,
             SecurityType.Future,
+            SecurityType.Index,
         };
 
         private readonly HashSet<OrderType> _supportedOrderTypes = new()

--- a/Tests/Common/Brokerages/TerminalLinkBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/TerminalLinkBrokerageModelTests.cs
@@ -31,6 +31,7 @@ namespace QuantConnect.Tests.Common.Brokerages
         [TestCase("SPY", SecurityType.Option)]
         [TestCase("SPX", SecurityType.IndexOption)]
         [TestCase("ES", SecurityType.Future)]
+        [TestCase("SPX", SecurityType.Index)]
         public void CanSubmitOrder_ForSupportedSecurityTypes(string ticker, SecurityType securityType)
         {
             var algo = new AlgorithmStub();
@@ -41,12 +42,10 @@ namespace QuantConnect.Tests.Common.Brokerages
             Assert.IsNull(message);
         }
 
-        // Index is data-only on TerminalLink; Forex/Crypto/Cfd and FutureOption
-        // are not supported for trading.
+        // Forex/Crypto/Cfd and FutureOption are not tradable on TerminalLink
         [TestCase("EURUSD", SecurityType.Forex)]
         [TestCase("BTCUSD", SecurityType.Crypto)]
         [TestCase("DE10YBEUR", SecurityType.Cfd)]
-        [TestCase("SPX", SecurityType.Index)]
         public void CannotSubmitOrder_ForUnsupportedSecurityTypes(string ticker, SecurityType securityType)
         {
             var algo = new AlgorithmStub();
@@ -56,6 +55,19 @@ namespace QuantConnect.Tests.Common.Brokerages
             Assert.IsFalse(_brokerageModel.CanSubmitOrder(security, order, out var message));
             Assert.AreEqual(BrokerageMessageType.Warning, message.Type);
             Assert.AreEqual("NotSupported", message.Code);
+        }
+
+        // A custom basket that quotes as an index is booked on EMSX as a CFD/swap
+        [Test]
+        public void CanSubmitOrder_ForIndex_BookedAsCfdTrade()
+        {
+            var algo = new AlgorithmStub();
+            var security = algo.AddSecurity(SecurityType.Index, "SPX");
+            var properties = new TerminalLinkOrderProperties { IsCfdTrade = true };
+            var order = new MarketOrder(security.Symbol, 1, new DateTime(2024, 1, 2), properties: properties);
+
+            Assert.IsTrue(_brokerageModel.CanSubmitOrder(security, order, out var message), message?.Message);
+            Assert.IsNull(message);
         }
 
         [TestCase(OrderType.Market)]


### PR DESCRIPTION
## Description

`TerminalLinkBrokerageModel.CanSubmitOrder` rejected every `SecurityType.Index` order, which blocked a supported Bloomberg EMSX workflow: booking a custom basket (e.g. a Morgan Stanley basket swap) whose market data arrives through B-Pipe as an index, by typing the index ticker into the EMSX security field and routing the ticket as a CFD/swap.

`TerminalLinkBrokerage.PlaceOrder` already sends `EMSX_CFD_FLAG` (from `TerminalLinkOrderProperties.IsCfdTrade`) and `TerminalLinkSymbolMapper` already resolves index tickers, so the engine-level pre-flight check was the only thing in the way.

EMSX accepts an index ticker in the security field, so `Index` joins `_supportedSecurityTypes` rather than being gated on the CFD flag — that flag is an order-level booking type that is independent of the security type by design, as its documentation states. The existing `Security.IsTradable` opt-in for indices still applies upstream of the brokerage model, so a data-only index is still rejected before it reaches here.

Closes #9747

## Related Issue

Closes #9747

## Motivation and Context

Reported by a live Institution user whose order was invalidated with `BrokerageModel declared unable to submit order: ... The TerminalLinkBrokerageModel does not support Index security type.` even though the order was explicitly flagged `IsCfdTrade = true`. In a standard (non-LEAN) EMSX ticket this booking flow is normal and supported.

## Requires Documentation Change

No.

## How Has This Been Tested?

`TerminalLinkBrokerageModelTests`: the `SPX`/`SecurityType.Index` case moved from `CannotSubmitOrder_ForUnsupportedSecurityTypes` to `CanSubmitOrder_ForSupportedSecurityTypes`, plus a new `CanSubmitOrder_ForIndex_BookedAsCfdTrade` covering the reported workflow — an index order carrying `TerminalLinkOrderProperties { IsCfdTrade = true }`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
