### PR TITLE
Reject an ARIMA period too short for its own orders

### DIFF
--- a/Indicators/AutoRegressiveIntegratedMovingAverage.cs
+++ b/Indicators/AutoRegressiveIntegratedMovingAverage.cs
@@ -131,9 +131,14 @@ namespace QuantConnect.Indicators
                     "currently available fitting methods.");
             }
 
-            if (period < Math.Max(arOrder, maOrder))
+            // ComputeNextValue indexes arrayData and _residuals up to 2 * maOrder, over a
+            // series DifferenceSeries shortens only when diffOrder is positive.
+            var shortest = Math.Max(arOrder, maOrder > 0 ? (2 * maOrder) + 1 : 0)
+                + Math.Max(diffOrder, 0);
+            if (period < shortest)
             {
-                throw new ArgumentException("Period must exceed both arOrder and maOrder");
+                throw new ArgumentException($"Period parameter for ARIMA({arOrder}, {diffOrder}, " +
+                    $"{maOrder}) indicator must be at least {shortest} but was {period}");
             }
 
             _arOrder = arOrder;

--- a/Tests/Indicators/AutoregressiveIntegratedMovingAverageTests.cs
+++ b/Tests/Indicators/AutoregressiveIntegratedMovingAverageTests.cs
@@ -69,6 +69,31 @@ namespace QuantConnect.Tests.Indicators
             Assert.IsTrue(arima.IsReady);
         }
 
+        [TestCase(1, 0, 1, 3)]
+        [TestCase(1, 1, 1, 4)]
+        [TestCase(2, 1, 2, 6)]
+        [TestCase(1, 2, 0, 3)]
+        [TestCase(1, -2, 1, 3)]
+        [TestCase(1, -3, 2, 5)]
+        public void RejectsAPeriodTooShortForItsOrders(int arOrder, int diffOrder, int maOrder, int shortest)
+        {
+            var exception = Assert.Throws<ArgumentException>(() =>
+                new AutoRegressiveIntegratedMovingAverage(arOrder, diffOrder, maOrder, shortest - 1, true));
+            Assert.That(exception.Message, Is.EqualTo(
+                $"Period parameter for ARIMA({arOrder}, {diffOrder}, {maOrder}) indicator " +
+                $"must be at least {shortest} but was {shortest - 1}"));
+
+            var arima = new AutoRegressiveIntegratedMovingAverage(arOrder, diffOrder, maOrder, shortest, true);
+            var reference = new DateTime(2020, 1, 1);
+
+            for (var i = 0; i < shortest + 1; i++)
+            {
+                arima.Update(reference.AddDays(i), 100m + (decimal)Math.Sin(i / 3d) * 5m);
+            }
+
+            Assert.IsTrue(arima.IsReady);
+        }
+
         [Test]
         public void PredictionErrorAgainstExternalData()
         {


### PR DESCRIPTION
#### Description

`AutoRegressiveIntegratedMovingAverage` checks `period < Math.Max(arOrder, maOrder)`, which is weaker than what `ComputeNextValue` reads: `arrayData[arOrder - 1]` and `_residuals[2 * maOrder]`, over a series `DifferenceSeries` shortens. The guard now asks for `Math.Max(arOrder, 2 * maOrder + 1) + Math.Max(diffOrder, 0)`, and its message follows the wording `Beta`, `Correlation` and `ValueAtRisk` already use.

The clamp on `diffOrder` is there because nothing validates it as non-negative and `DifferenceSeries` runs only when it is positive, so a negative one costs no samples.

#### Related Issue

Closes #9757.

#### Motivation and Context

168 of the 534 order sets the old guard admits throw on the bar that fills the window, 127 at line 209 and 41 at line 201, before the indicator reports ready. `HandleExceptions` does not cover them: it wraps the two fitting steps, and both reads are in `ComputeNextValue`. With the change 366 of the 600 are admitted and none throws, so the same 168 are refused and nothing that works today is.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

`RejectsAPeriodTooShortForItsOrders` takes six order sets, two of them with a negative `diffOrder`, and asserts both sides of the boundary and the exception text. The ARIMA fixture is 22 passed; reverting the guard fails four cases and reverting the clamp fails the other two.

`IndicatorResetContractTests` gives 1140 passed and 72 skipped on this branch and on master alike, which is where a stricter constructor would show since it builds every indicator at periods 1, 2 and 14. Every ARIMA in the repository is built at period 50, where nothing changes either way.
