### PR TITLE
Warn once for coarse option underlying resolution

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -107,6 +107,7 @@ namespace QuantConnect.Algorithm
         private bool _tagsLimitReachedLogSent;
         private bool _tagsCollectionTruncatedLogSent;
         private bool _hasShownDailyConsolidationWarning;
+        private bool _optionContractUnderlyingResolutionWarningSent;
         private bool _indexOptionTickerAsUnderlyingWarningSent;
         private DateTime _start;
         private DateTime _startDate;   //Default start and end dates.
@@ -2456,10 +2457,11 @@ namespace QuantConnect.Algorithm
 
             var optionResolution = resolution ?? UniverseSettings.Resolution;
             var underlyingResolution = underlyingConfigs.GetHighestResolution();
-            if (underlyingResolution > optionResolution)
+            if (underlyingResolution > optionResolution && !_optionContractUnderlyingResolutionWarningSent)
             {
-                throw new ArgumentException(Messages.QCAlgorithm.AddOptionContractUnderlyingResolution(
-                    symbol, optionResolution, underlying, underlyingResolution));
+                Debug($"Warning: {Messages.QCAlgorithm.AddOptionContractUnderlyingResolution(
+                    symbol, optionResolution, underlying, underlyingResolution)}");
+                _optionContractUnderlyingResolutionWarningSent = true;
             }
 
             var configs = SubscriptionManager.SubscriptionDataConfigService.Add(symbol, resolution, fillForward, extendedMarketHours,

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -2454,6 +2454,14 @@ namespace QuantConnect.Algorithm
                 }
             }
 
+            var optionResolution = resolution ?? UniverseSettings.Resolution;
+            var underlyingResolution = underlyingConfigs.GetHighestResolution();
+            if (underlyingResolution > optionResolution)
+            {
+                throw new ArgumentException(Messages.QCAlgorithm.AddOptionContractUnderlyingResolution(
+                    symbol, optionResolution, underlying, underlyingResolution));
+            }
+
             var configs = SubscriptionManager.SubscriptionDataConfigService.Add(symbol, resolution, fillForward, extendedMarketHours,
                 dataNormalizationMode: DataNormalizationMode.Raw);
             var option = (Option)Securities.CreateSecurity(symbol, configs, leverage, underlying: underlyingSecurity);

--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -107,7 +107,7 @@ namespace QuantConnect.Algorithm
         private bool _tagsLimitReachedLogSent;
         private bool _tagsCollectionTruncatedLogSent;
         private bool _hasShownDailyConsolidationWarning;
-        private bool _optionContractUnderlyingResolutionWarningSent;
+        private bool _optionUnderlyingResolutionWarningSent;
         private bool _indexOptionTickerAsUnderlyingWarningSent;
         private DateTime _start;
         private DateTime _startDate;   //Default start and end dates.
@@ -2199,6 +2199,9 @@ namespace QuantConnect.Algorithm
                 canonicalSymbol = QuantConnect.Symbol.CreateCanonicalOption(underlying, targetOption, market, alias);
             }
 
+            WarnIfUnderlyingResolutionIsCoarser(canonicalSymbol,
+                SubscriptionManager.SubscriptionDataConfigService.GetSubscriptionDataConfigs(underlying), resolution);
+
             return (Option)AddSecurity(canonicalSymbol, resolution, fillForward, leverage);
         }
 
@@ -2400,6 +2403,26 @@ namespace QuantConnect.Algorithm
         }
 
         /// <summary>
+        /// Warns once if the option resolution is finer than the existing underlying subscription,
+        /// since the option pricing models would then use a stale underlying price
+        /// </summary>
+        private void WarnIfUnderlyingResolutionIsCoarser(Symbol option, List<SubscriptionDataConfig> underlyingConfigs, Resolution? optionResolution)
+        {
+            if (_optionUnderlyingResolutionWarningSent || underlyingConfigs.Count == 0)
+            {
+                return;
+            }
+
+            var resolution = optionResolution ?? UniverseSettings.Resolution;
+            var underlyingResolution = underlyingConfigs.GetHighestResolution();
+            if (underlyingResolution > resolution)
+            {
+                Debug($"Warning: {Messages.QCAlgorithm.OptionUnderlyingResolutionIsCoarser(option, resolution, underlyingResolution)}");
+                _optionUnderlyingResolutionWarningSent = true;
+            }
+        }
+
+        /// <summary>
         /// Creates and adds a new single <see cref="Option"/> contract to the algorithm
         /// </summary>
         /// <param name="symbol">The option contract symbol</param>
@@ -2455,14 +2478,7 @@ namespace QuantConnect.Algorithm
                 }
             }
 
-            var optionResolution = resolution ?? UniverseSettings.Resolution;
-            var underlyingResolution = underlyingConfigs.GetHighestResolution();
-            if (underlyingResolution > optionResolution && !_optionContractUnderlyingResolutionWarningSent)
-            {
-                Debug($"Warning: {Messages.QCAlgorithm.AddOptionContractUnderlyingResolution(
-                    symbol, optionResolution, underlying, underlyingResolution)}");
-                _optionContractUnderlyingResolutionWarningSent = true;
-            }
+            WarnIfUnderlyingResolutionIsCoarser(symbol, underlyingConfigs, resolution);
 
             var configs = SubscriptionManager.SubscriptionDataConfigService.Add(symbol, resolution, fillForward, extendedMarketHours,
                 dataNormalizationMode: DataNormalizationMode.Raw);

--- a/Common/Messages/Messages.Algorithm.cs
+++ b/Common/Messages/Messages.Algorithm.cs
@@ -99,6 +99,18 @@ namespace QuantConnect
                 return $"{AlgorithmPrefix()}.{FormatCode("AddData")}(): the first argument must be a custom data type (a Python class deriving from {FormatCode("PythonData")} or a CLR {FormatCode("BaseData")} type), but received {repr}. " +
                     $"To subscribe to built-in asset classes use, for example, {FormatCode("AddEquity")} or {FormatCode("AddCrypto")}.";
             }
+
+            /// <summary>
+            /// Returns a string message saying an option cannot use a finer resolution than its underlying
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static string AddOptionContractUnderlyingResolution(global::QuantConnect.Symbol option, Resolution optionResolution,
+                global::QuantConnect.Symbol underlying, Resolution underlyingResolution)
+            {
+                return $"{AlgorithmPrefix()}.{FormatCode("AddOptionContract")}(): option contract {option} uses {optionResolution} resolution, " +
+                    $"which is finer than its underlying {underlying} subscription at {underlyingResolution} resolution. " +
+                    $"Add the underlying at {optionResolution} resolution or finer before adding the option contract so its implied volatility and Greeks use a current underlying price.";
+            }
         }
 
         /// <summary>

--- a/Common/Messages/Messages.Algorithm.cs
+++ b/Common/Messages/Messages.Algorithm.cs
@@ -101,7 +101,7 @@ namespace QuantConnect
             }
 
             /// <summary>
-            /// Returns a string message saying an option cannot use a finer resolution than its underlying
+            /// Returns a warning message saying an option uses a finer resolution than its underlying
             /// </summary>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static string AddOptionContractUnderlyingResolution(global::QuantConnect.Symbol option, Resolution optionResolution,

--- a/Common/Messages/Messages.Algorithm.cs
+++ b/Common/Messages/Messages.Algorithm.cs
@@ -104,12 +104,10 @@ namespace QuantConnect
             /// Returns a warning message saying an option uses a finer resolution than its underlying
             /// </summary>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static string AddOptionContractUnderlyingResolution(global::QuantConnect.Symbol option, Resolution optionResolution,
-                global::QuantConnect.Symbol underlying, Resolution underlyingResolution)
+            public static string OptionUnderlyingResolutionIsCoarser(global::QuantConnect.Symbol option, Resolution optionResolution, Resolution underlyingResolution)
             {
-                return $"{AlgorithmPrefix()}.{FormatCode("AddOptionContract")}(): option contract {option} uses {optionResolution} resolution, " +
-                    $"which is finer than its underlying {underlying} subscription at {underlyingResolution} resolution. " +
-                    $"Add the underlying at {optionResolution} resolution or finer before adding the option contract so its implied volatility and Greeks use a current underlying price.";
+                return $"Option {option} uses {optionResolution} resolution but its underlying {option.Underlying} uses {underlyingResolution}, " +
+                    $"so Greeks and implied volatility will use stale prices. Add the underlying at {optionResolution} resolution or finer.";
             }
         }
 

--- a/Tests/Algorithm/AlgorithmAddDataTests.cs
+++ b/Tests/Algorithm/AlgorithmAddDataTests.cs
@@ -728,23 +728,21 @@ namespace QuantConnect.Tests.Algorithm
         [TestCase(Resolution.Hour, Resolution.Minute, true)]
         [TestCase(Resolution.Minute, Resolution.Minute, false)]
         [TestCase(Resolution.Second, Resolution.Minute, false)]
-        public void AddOptionContractValidatesUnderlyingResolution(
-            Resolution underlyingResolution, Resolution optionResolution, bool shouldThrow)
+        public void AddOptionContractWarnsForCoarseUnderlyingResolution(
+            Resolution underlyingResolution, Resolution optionResolution, bool shouldWarn)
         {
             var algorithm = Algorithm();
             var underlying = algorithm.AddEquity("SPY", underlyingResolution).Symbol;
             var option = Symbol.CreateOption(underlying, Market.USA, OptionStyle.American, OptionRight.Call,
                 100m, new DateTime(2027, 1, 15));
 
-            if (shouldThrow)
+            Assert.DoesNotThrow(() => algorithm.AddOptionContract(option, optionResolution));
+
+            var warnings = algorithm.DebugMessages.Where(message => message.Contains("finer than its underlying")).ToList();
+            Assert.AreEqual(shouldWarn ? 1 : 0, warnings.Count);
+            if (shouldWarn)
             {
-                var exception = Assert.Throws<ArgumentException>(() => algorithm.AddOptionContract(option, optionResolution));
-                StringAssert.Contains("finer than its underlying", exception.Message);
-                StringAssert.Contains($"Add the underlying at {optionResolution} resolution or finer", exception.Message);
-            }
-            else
-            {
-                Assert.DoesNotThrow(() => algorithm.AddOptionContract(option, optionResolution));
+                StringAssert.Contains($"Add the underlying at {optionResolution} resolution or finer", warnings.Single());
             }
         }
 
@@ -761,15 +759,20 @@ namespace QuantConnect.Tests.Algorithm
         }
 
         [Test]
-        public void AddOptionContractValidatesUnderlyingResolutionFromUniverseSettings()
+        public void AddOptionContractWarnsOnceForCoarseUnderlyingResolution()
         {
             var algorithm = Algorithm();
             algorithm.UniverseSettings.Resolution = Resolution.Minute;
             var underlying = algorithm.AddEquity("SPY", Resolution.Daily).Symbol;
-            var option = Symbol.CreateOption(underlying, Market.USA, OptionStyle.American, OptionRight.Call,
+            var firstOption = Symbol.CreateOption(underlying, Market.USA, OptionStyle.American, OptionRight.Call,
                 100m, new DateTime(2027, 1, 15));
+            var secondOption = Symbol.CreateOption(underlying, Market.USA, OptionStyle.American, OptionRight.Put,
+                105m, new DateTime(2027, 1, 15));
 
-            Assert.Throws<ArgumentException>(() => algorithm.AddOptionContract(option));
+            Assert.DoesNotThrow(() => algorithm.AddOptionContract(firstOption));
+            Assert.DoesNotThrow(() => algorithm.AddOptionContract(secondOption));
+
+            Assert.AreEqual(1, algorithm.DebugMessages.Count(message => message.Contains("finer than its underlying")));
         }
 
         private static SubscriptionDataConfig GetMatchingSubscription(QCAlgorithm algorithm, Symbol symbol, Type type)

--- a/Tests/Algorithm/AlgorithmAddDataTests.cs
+++ b/Tests/Algorithm/AlgorithmAddDataTests.cs
@@ -724,6 +724,54 @@ namespace QuantConnect.Tests.Algorithm
             Assert.IsTrue(exception.Message.Contains("is delisted"), $"Unexpected exception message: {exception.Message}");
         }
 
+        [TestCase(Resolution.Daily, Resolution.Minute, true)]
+        [TestCase(Resolution.Hour, Resolution.Minute, true)]
+        [TestCase(Resolution.Minute, Resolution.Minute, false)]
+        [TestCase(Resolution.Second, Resolution.Minute, false)]
+        public void AddOptionContractValidatesUnderlyingResolution(
+            Resolution underlyingResolution, Resolution optionResolution, bool shouldThrow)
+        {
+            var algorithm = Algorithm();
+            var underlying = algorithm.AddEquity("SPY", underlyingResolution).Symbol;
+            var option = Symbol.CreateOption(underlying, Market.USA, OptionStyle.American, OptionRight.Call,
+                100m, new DateTime(2027, 1, 15));
+
+            if (shouldThrow)
+            {
+                var exception = Assert.Throws<ArgumentException>(() => algorithm.AddOptionContract(option, optionResolution));
+                StringAssert.Contains("finer than its underlying", exception.Message);
+                StringAssert.Contains($"Add the underlying at {optionResolution} resolution or finer", exception.Message);
+            }
+            else
+            {
+                Assert.DoesNotThrow(() => algorithm.AddOptionContract(option, optionResolution));
+            }
+        }
+
+        [Test]
+        public void AddOptionContractUsesHighestAvailableUnderlyingResolution()
+        {
+            var algorithm = Algorithm();
+            var underlying = algorithm.AddEquity("SPY", Resolution.Daily).Symbol;
+            algorithm.AddEquity("SPY", Resolution.Minute);
+            var option = Symbol.CreateOption(underlying, Market.USA, OptionStyle.American, OptionRight.Call,
+                100m, new DateTime(2027, 1, 15));
+
+            Assert.DoesNotThrow(() => algorithm.AddOptionContract(option, Resolution.Minute));
+        }
+
+        [Test]
+        public void AddOptionContractValidatesUnderlyingResolutionFromUniverseSettings()
+        {
+            var algorithm = Algorithm();
+            algorithm.UniverseSettings.Resolution = Resolution.Minute;
+            var underlying = algorithm.AddEquity("SPY", Resolution.Daily).Symbol;
+            var option = Symbol.CreateOption(underlying, Market.USA, OptionStyle.American, OptionRight.Call,
+                100m, new DateTime(2027, 1, 15));
+
+            Assert.Throws<ArgumentException>(() => algorithm.AddOptionContract(option));
+        }
+
         private static SubscriptionDataConfig GetMatchingSubscription(QCAlgorithm algorithm, Symbol symbol, Type type)
         {
             // find a subscription matchin the requested type with a higher resolution than requested

--- a/Tests/Algorithm/AlgorithmAddDataTests.cs
+++ b/Tests/Algorithm/AlgorithmAddDataTests.cs
@@ -738,7 +738,7 @@ namespace QuantConnect.Tests.Algorithm
 
             Assert.DoesNotThrow(() => algorithm.AddOptionContract(option, optionResolution));
 
-            var warnings = algorithm.DebugMessages.Where(message => message.Contains("finer than its underlying")).ToList();
+            var warnings = algorithm.DebugMessages.Where(message => message.Contains("but its underlying")).ToList();
             Assert.AreEqual(shouldWarn ? 1 : 0, warnings.Count);
             if (shouldWarn)
             {
@@ -756,6 +756,32 @@ namespace QuantConnect.Tests.Algorithm
                 100m, new DateTime(2027, 1, 15));
 
             Assert.DoesNotThrow(() => algorithm.AddOptionContract(option, Resolution.Minute));
+
+            Assert.IsFalse(algorithm.DebugMessages.Any(message => message.Contains("but its underlying")));
+        }
+
+        [TestCase(Resolution.Daily, Resolution.Minute, true)]
+        [TestCase(Resolution.Minute, Resolution.Minute, false)]
+        [TestCase(Resolution.Second, Resolution.Minute, false)]
+        public void AddOptionWarnsForCoarseUnderlyingResolution(
+            Resolution underlyingResolution, Resolution optionResolution, bool shouldWarn)
+        {
+            var algorithm = Algorithm();
+            algorithm.AddEquity("SPY", underlyingResolution);
+
+            Assert.DoesNotThrow(() => algorithm.AddOption("SPY", optionResolution));
+
+            Assert.AreEqual(shouldWarn ? 1 : 0, algorithm.DebugMessages.Count(message => message.Contains("but its underlying")));
+        }
+
+        [Test]
+        public void AddOptionDoesNotWarnWhenUnderlyingIsNotPresent()
+        {
+            var algorithm = Algorithm();
+
+            Assert.DoesNotThrow(() => algorithm.AddOption("SPY", Resolution.Minute));
+
+            Assert.IsFalse(algorithm.DebugMessages.Any(message => message.Contains("but its underlying")));
         }
 
         [Test]
@@ -772,7 +798,7 @@ namespace QuantConnect.Tests.Algorithm
             Assert.DoesNotThrow(() => algorithm.AddOptionContract(firstOption));
             Assert.DoesNotThrow(() => algorithm.AddOptionContract(secondOption));
 
-            Assert.AreEqual(1, algorithm.DebugMessages.Count(message => message.Contains("finer than its underlying")));
+            Assert.AreEqual(1, algorithm.DebugMessages.Count(message => message.Contains("but its underlying")));
         }
 
         private static SubscriptionDataConfig GetMatchingSubscription(QCAlgorithm algorithm, Symbol symbol, Type type)


### PR DESCRIPTION
#### Description

Replaces the fatal validation from #9751 with a one-time warning, as requested in the maintainer review.

When an option contract uses a finer resolution than the finest existing underlying subscription, `AddOptionContract` now:

- emits a `Debug` warning once per algorithm;
- continues adding the option contract;
- recommends adding the underlying at the option resolution or finer so implied volatility and Greeks use a current price.

The validation still uses the finest available underlying subscription and `UniverseSettings.Resolution` when the option resolution is omitted.

#### Related Issue

Closes #9732.
Supersedes #9751 after GitHub rejected reopening the closed pull request.

#### Motivation and Context

LEAN computes option implied volatility and Greeks from the underlying's latest price. A finer option subscription can therefore use a stale underlying price. A warning surfaces that risk without blocking users for whom a coarser underlying resolution is the best available data.

#### Requires Documentation Change

No. The warning explains the resolution relationship and recommended action.

#### How Has This Been Tested?

- Built `Tests/QuantConnect.Tests.csproj` in Release mode with .NET 10: 0 errors.
- Ran all tests matching `AlgorithmAddDataTests.AddOptionContract`: 9 passed, 0 failed.
- Ran the complete `AlgorithmAddDataTests` fixture: 54 passed; the only two failures were existing Python/Pandas tests because the minimal container does not include pandas, and neither test exercises this change.
- Ran `git diff --check` successfully.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature
- [ ] Breaking change
- [ ] Non-functional change

#### Checklist

- [x] My code follows the code style of this project.
- [x] I have read the contributing document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed. (All relevant and non-Pandas fixture tests pass; two unrelated Python/Pandas tests require the upstream environment.)
- [x] My branch follows the project naming convention.