### PR TITLE
Adjust runtime statistics handling

### DIFF
--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -783,7 +783,7 @@ namespace QuantConnect.Lean.Engine.Results
         {
             lock (RuntimeStatistics)
             {
-                RuntimeStatistics[key] = value;
+                TrySetRuntimeStatistic(key, value);
             }
         }
 

--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -950,6 +950,127 @@ namespace QuantConnect.Lean.Engine.Results
             ISeriesPoint value,
             string unit = "$");
 
+        private bool _runtimeStatisticRejectedWarningSent;
+
+        /// <summary>
+        /// Maximum number of runtime statistics
+        /// </summary>
+        public const int MaxRuntimeStatisticsCount = 50;
+
+        /// <summary>
+        /// Maximum length of a runtime statistic key and value
+        /// </summary>
+        public const int MaxRuntimeStatisticLength = 200;
+
+        /// <summary>
+        /// Stores a runtime statistic, enforcing the configured count, length and format limits.
+        /// Callers must hold the <see cref="RuntimeStatistics"/> lock.
+        /// </summary>
+        /// <param name="key">Runtime headline statistic name</param>
+        /// <param name="value">Runtime headline statistic value</param>
+        /// <returns>True if the statistic was stored</returns>
+        protected bool TrySetRuntimeStatistic(string key, string value)
+        {
+            if (string.IsNullOrEmpty(key))
+            {
+                return false;
+            }
+            value ??= string.Empty;
+
+            if (key.Length > MaxRuntimeStatisticLength)
+            {
+                key = key.Substring(0, MaxRuntimeStatisticLength);
+            }
+            if (value.Length > MaxRuntimeStatisticLength)
+            {
+                value = value.Substring(0, MaxRuntimeStatisticLength);
+            }
+
+            if (IsEncodedRuntimeStatistic(key) || IsEncodedRuntimeStatistic(value))
+            {
+                SendRuntimeStatisticRejectedWarning($"Runtime statistic '{key}' was ignored: encoded values are not supported, statistics must be human readable text.");
+                return false;
+            }
+
+            if (!RuntimeStatistics.ContainsKey(key) && RuntimeStatistics.Count >= MaxRuntimeStatisticsCount)
+            {
+                SendRuntimeStatisticRejectedWarning($"Runtime statistic '{key}' was ignored: exceeded maximum runtime statistics count, new statistics will be ignored. Limit is currently set at {MaxRuntimeStatisticsCount}.");
+                return false;
+            }
+
+            RuntimeStatistics[key] = value;
+            return true;
+        }
+
+        /// <summary>
+        /// Sends a one time debug message to the algorithm when a runtime statistic is rejected
+        /// </summary>
+        private void SendRuntimeStatisticRejectedWarning(string message)
+        {
+            if (_runtimeStatisticRejectedWarningSent)
+            {
+                return;
+            }
+            _runtimeStatisticRejectedWarningSent = true;
+
+            if (this is IResultHandler resultHandler)
+            {
+                resultHandler.DebugMessage(message);
+            }
+            else
+            {
+                Log.Trace($"BaseResultsHandler.TrySetRuntimeStatistic(): {message}");
+            }
+        }
+
+        /// <summary>
+        /// Determines whether the given text looks like an encoded blob (base64 or hexadecimal) rather than a human readable statistic
+        /// </summary>
+        private static bool IsEncodedRuntimeStatistic(string text)
+        {
+            const int minimumLength = 16;
+            if (text.Length < minimumLength)
+            {
+                return false;
+            }
+
+            var isHex = true;
+            var hasUpper = false;
+            var hasLower = false;
+            var hasDigit = false;
+            var hasLetter = false;
+            foreach (var c in text)
+            {
+                if (char.IsUpper(c))
+                {
+                    hasUpper = true;
+                    hasLetter = true;
+                }
+                else if (char.IsLower(c))
+                {
+                    hasLower = true;
+                    hasLetter = true;
+                }
+                else if (char.IsDigit(c))
+                {
+                    hasDigit = true;
+                }
+                else if (c != '+' && c != '/' && c != '=' && c != '-' && c != '_')
+                {
+                    // whitespace, punctuation, currency symbols, etc. => human readable
+                    return false;
+                }
+
+                if (isHex && !Uri.IsHexDigit(c))
+                {
+                    isHex = false;
+                }
+            }
+
+            // a plain number is fine, hex needs at least one letter; base64 mixes cases and digits
+            return (isHex && hasLetter) || (hasUpper && hasLower && hasDigit);
+        }
+
         /// <summary>
         /// Gets the algorithm runtime statistics
         /// </summary>

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -809,11 +809,7 @@ namespace QuantConnect.Lean.Engine.Results
             Log.Debug("LiveTradingResultHandler.RuntimeStatistic(): Begin setting statistic");
             lock (RuntimeStatistics)
             {
-                if (!RuntimeStatistics.ContainsKey(key))
-                {
-                    RuntimeStatistics.Add(key, value);
-                }
-                RuntimeStatistics[key] = value;
+                TrySetRuntimeStatistic(key, value);
             }
             Log.Debug("LiveTradingResultHandler.RuntimeStatistic(): End setting statistic");
         }

--- a/Tests/Engine/Results/BaseResultsHandlerTests.cs
+++ b/Tests/Engine/Results/BaseResultsHandlerTests.cs
@@ -207,6 +207,10 @@ namespace QuantConnect.Tests.Engine.Results
 
             public void CallSetAlgorithmState(string error, string stack) => SetAlgorithmState(error, stack);
 
+            public bool CallTrySetRuntimeStatistic(string key, string value) => TrySetRuntimeStatistic(key, value);
+
+            public Dictionary<string, string> GetRuntimeStatistics => RuntimeStatistics;
+
             protected override void Run()
             {
                 throw new NotImplementedException();
@@ -230,6 +234,56 @@ namespace QuantConnect.Tests.Engine.Results
             protected override void AddToLogStore(string message)
             {
             }
+        }
+
+        [TestCase("Some readable value $1,234.56", true)]
+        [TestCase("Long Only Strategy", true)]
+        [TestCase("123456789012345678901234567890", true)]
+        [TestCase("BUY", true)]
+        [TestCase("TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQ=", false)]
+        [TestCase("aGVsbG8gd29ybGQ=", false)]
+        [TestCase("48656c6c6f20576f726c6421", false)]
+        [TestCase("DEADBEEFDEADBEEF", false)]
+        [TestCase("Stop Loss Hit 3 Times Today", true)]
+        [TestCase("Avg Fill Price 123.45 USD", true)]
+        [TestCase("SPY,QQQ,IWM,TLT,GLD,USO", true)]
+        public void RuntimeStatisticRejectsEncodedValues(string value, bool expected)
+        {
+            var handler = new BaseResultsHandlerTestable(AlgorithmId);
+
+            Assert.AreEqual(expected, handler.CallTrySetRuntimeStatistic("Key", value));
+            Assert.AreEqual(expected, handler.CallTrySetRuntimeStatistic(value, "value"));
+        }
+
+        [Test]
+        public void RuntimeStatisticTruncatesLongKeysAndValues()
+        {
+            var handler = new BaseResultsHandlerTestable(AlgorithmId);
+            var longText = string.Join(" ", Enumerable.Repeat("word", 100));
+            Assert.Greater(longText.Length, BaseResultsHandler.MaxRuntimeStatisticLength);
+
+            Assert.IsTrue(handler.CallTrySetRuntimeStatistic(longText, longText));
+
+            var pair = handler.GetRuntimeStatistics.Single();
+            Assert.AreEqual(BaseResultsHandler.MaxRuntimeStatisticLength, pair.Key.Length);
+            Assert.AreEqual(BaseResultsHandler.MaxRuntimeStatisticLength, pair.Value.Length);
+        }
+
+        [Test]
+        public void RuntimeStatisticCapsCount()
+        {
+            var handler = new BaseResultsHandlerTestable(AlgorithmId);
+            for (var i = 0; i < BaseResultsHandler.MaxRuntimeStatisticsCount; i++)
+            {
+                Assert.IsTrue(handler.CallTrySetRuntimeStatistic($"Key {i}", $"{i}"));
+            }
+
+            Assert.IsFalse(handler.CallTrySetRuntimeStatistic("One too many", "1"));
+            Assert.AreEqual(BaseResultsHandler.MaxRuntimeStatisticsCount, handler.GetRuntimeStatistics.Count);
+
+            // updating an existing key is still allowed
+            Assert.IsTrue(handler.CallTrySetRuntimeStatistic("Key 0", "updated"));
+            Assert.AreEqual("updated", handler.GetRuntimeStatistics["Key 0"]);
         }
 
         [Test]

--- a/Tests/Engine/Results/LiveTradingResultHandlerTests.cs
+++ b/Tests/Engine/Results/LiveTradingResultHandlerTests.cs
@@ -446,6 +446,31 @@ namespace QuantConnect.Tests.Engine.Results
         }
 
         [Test]
+        public void RuntimeStatisticRejectionWarnsOnce()
+        {
+            using var messaging = new QuantConnect.Messaging.Messaging();
+            var result = new LiveTradingResultHandler();
+            result.Initialize(new(new LiveNodePacket(), messaging, null, new BacktestingTransactionHandler(), null));
+
+            var algorithm = new AlgorithmStub();
+            algorithm.SetDateTime(new DateTime(2026, 1, 15, 9, 30, 0));
+            result.SetAlgorithm(algorithm, 10);
+            result.Messages.Clear();
+
+            result.RuntimeStatistic("Valid", "ok");
+            result.RuntimeStatistic("Encoded", "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQ=");
+            result.RuntimeStatistic("Encoded", "48656c6c6f20576f726c6421");
+            for (var i = 0; i < BaseResultsHandler.MaxRuntimeStatisticsCount + 10; i++)
+            {
+                result.RuntimeStatistic($"Key {i}", "1");
+            }
+
+            var debugMessages = result.Messages.OfType<DebugPacket>().ToList();
+            Assert.AreEqual(1, debugMessages.Count);
+            Assert.That(debugMessages[0].Message, Does.Contain("Runtime statistic"));
+        }
+
+        [Test]
         public void StoredResultsCarryServerStatistics()
         {
             using var api = new Api.Api();


### PR DESCRIPTION
Consolidates the runtime statistics update path in `BaseResultsHandler` so both the backtesting and live result handlers share a single code path.

While at it, adds a few sanity limits to the values that get stored in the runtime statistics header:

- Cap the number of runtime statistics kept (50).
- Cap key/value length (200 chars) and truncate longer entries.
- Skip entries whose key or value is not human readable text.
- Emit a one time debug message to the algorithm when an entry is skipped, so it is not silently dropped.

Adds unit tests covering the count/length limits, the readable value check and the one time warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bjhpjT5npGmtVjgLWaDRH
