### PR TITLE
fix: show the failed order in place order assertion

### DIFF
--- a/Tests/Brokerages/BrokerageTests.cs
+++ b/Tests/Brokerages/BrokerageTests.cs
@@ -768,7 +768,7 @@ namespace QuantConnect.Tests.Brokerages
                 OrderProvider.Add(order);
                 if (!Brokerage.PlaceOrder(order) && !allowFailedSubmission)
                 {
-                    Assert.Fail("Brokerage failed to place the order: " + orders);
+                    Assert.Fail($"Brokerage failed to place the order: {order}");
                 }
             }
 

--- a/Tests/Common/Orders/OrderTests.cs
+++ b/Tests/Common/Orders/OrderTests.cs
@@ -80,6 +80,14 @@ namespace QuantConnect.Tests.Common.Orders
             }
         }
 
+        [Test]
+        public void OrderToStringDescribesTheOrder()
+        {
+            var order = new MarketOrder(Symbols.SPY, 10, new DateTime(2024, 1, 1)) { Id = 7 };
+
+            Assert.AreEqual($"OrderId: 7 (BrokerId: ) None Market order for 10 units of {Symbols.SPY}", order.ToString());
+        }
+
         private static TestCaseData[] GetValueTestParameters()
         {
             const decimal delta = 1m;


### PR DESCRIPTION
#### Description
`PlaceOrderWaitForStatus` printed the whole order collection in the failure message, so NUnit showed the compiler generated list type instead of the order that failed.

Before:
```
Brokerage failed to place the order: <>z__ReadOnlySingleElementList`1[QuantConnect.Orders.Order]
```

After:
```
Brokerage failed to place the order: OrderId: 7 (BrokerId: ) None Market order for 10 units of SPY R735QTJ8P4090
```

#### Related Issue
N/A

#### Motivation and Context
When a brokerage test fails to submit an order, the message did not say which order failed. Now it shows the order id, status, type, quantity and symbol, so the failure can be read from the test output.

#### Requires Documentation Change
No

#### How Has This Been Tested?
New unit test `OrderTests.OrderToStringDescribesTheOrder` covers the readable text the assertion prints.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
