### PR TITLE
fix: take only market and limit orders on clear street options

### DIFF
--- a/Common/Brokerages/ClearStreetBrokerageModel.cs
+++ b/Common/Brokerages/ClearStreetBrokerageModel.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -50,6 +50,17 @@ namespace QuantConnect.Brokerages
             });
 
         /// <summary>
+        /// The order types Clear Street accepts on an option. A stop order of any kind is rejected
+        /// with "order_type Stop is not allowed for security_type Option".
+        /// </summary>
+        private readonly HashSet<OrderType> _supportOptionOrderTypes = new(
+            new[]
+            {
+                OrderType.Market,
+                OrderType.Limit
+            });
+
+        /// <summary>
         /// Constructor for Clear Street brokerage model
         /// </summary>
         /// <param name="accountType">Cash or Margin</param>
@@ -76,10 +87,12 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
-            if (!_supportOrderTypes.Contains(order.Type))
+            var supportOrderTypes = security.Type.IsOption() ? _supportOptionOrderTypes : _supportOrderTypes;
+
+            if (!supportOrderTypes.Contains(order.Type))
             {
                 message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
-                    Messages.DefaultBrokerageModel.UnsupportedOrderType(this, order, _supportOrderTypes));
+                    Messages.DefaultBrokerageModel.UnsupportedOrderType(this, order, supportOrderTypes));
                 return false;
             }
 

--- a/Common/Brokerages/ClearStreetBrokerageModel.cs
+++ b/Common/Brokerages/ClearStreetBrokerageModel.cs
@@ -26,39 +26,17 @@ namespace QuantConnect.Brokerages
     public class ClearStreetBrokerageModel : DefaultBrokerageModel
     {
         /// <summary>
-        /// The security types Clear Street accepts orders for.
+        /// A dictionary that maps each supported <see cref="SecurityType"/> to an array of <see cref="OrderType"/> supported by Clear Street brokerage.
         /// </summary>
-        private readonly HashSet<SecurityType> _supportSecurityTypes = new(
-            new[]
-            {
-                SecurityType.Equity,
-                SecurityType.Option,
-                SecurityType.IndexOption
-            });
-
-        /// <summary>
-        /// The order types supported by the <see cref="CanSubmitOrder"/> operation in Clear Street.
-        /// </summary>
-        private readonly HashSet<OrderType> _supportOrderTypes = new(
-            new[]
-            {
-                OrderType.Market,
-                OrderType.Limit,
-                OrderType.StopMarket,
-                OrderType.StopLimit,
-                OrderType.TrailingStop
-            });
-
-        /// <summary>
-        /// The order types Clear Street accepts on an option. A stop order of any kind is rejected
-        /// with "order_type Stop is not allowed for security_type Option".
-        /// </summary>
-        private readonly HashSet<OrderType> _supportOptionOrderTypes = new(
-            new[]
-            {
-                OrderType.Market,
-                OrderType.Limit
-            });
+        private readonly Dictionary<SecurityType, HashSet<OrderType>> _supportOrderTypeBySecurityType = new()
+        {
+            { SecurityType.Equity, new HashSet<OrderType> { OrderType.Market, OrderType.Limit, OrderType.StopMarket, OrderType.StopLimit,
+                OrderType.TrailingStop } },
+            // Market and limit order types, a stop order of an option is answered with
+            // "order_type Stop is not allowed for security_type Option"
+            { SecurityType.Option, new HashSet<OrderType> { OrderType.Market, OrderType.Limit } },
+            { SecurityType.IndexOption, new HashSet<OrderType> { OrderType.Market, OrderType.Limit } }
+        };
 
         /// <summary>
         /// Constructor for Clear Street brokerage model
@@ -78,16 +56,12 @@ namespace QuantConnect.Brokerages
         /// <returns>True if the brokerage could process the order, false otherwise</returns>
         public override bool CanSubmitOrder(Security security, Order order, out BrokerageMessageEvent message)
         {
-            message = default;
-
-            if (!_supportSecurityTypes.Contains(security.Type))
+            if (!_supportOrderTypeBySecurityType.TryGetValue(security.Type, out var supportOrderTypes))
             {
                 message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
                     Messages.DefaultBrokerageModel.UnsupportedSecurityType(this, security));
                 return false;
             }
-
-            var supportOrderTypes = security.Type.IsOption() ? _supportOptionOrderTypes : _supportOrderTypes;
 
             if (!supportOrderTypes.Contains(order.Type))
             {

--- a/Common/Brokerages/ClearStreetBrokerageModel.cs
+++ b/Common/Brokerages/ClearStreetBrokerageModel.cs
@@ -32,8 +32,6 @@ namespace QuantConnect.Brokerages
         {
             { SecurityType.Equity, new HashSet<OrderType> { OrderType.Market, OrderType.Limit, OrderType.StopMarket, OrderType.StopLimit,
                 OrderType.TrailingStop } },
-            // Market and limit order types, a stop order of an option is answered with
-            // "order_type Stop is not allowed for security_type Option"
             { SecurityType.Option, new HashSet<OrderType> { OrderType.Market, OrderType.Limit } },
             { SecurityType.IndexOption, new HashSet<OrderType> { OrderType.Market, OrderType.Limit } }
         };

--- a/Tests/Common/Brokerages/ClearStreetBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/ClearStreetBrokerageModelTests.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -27,7 +27,7 @@ namespace QuantConnect.Tests.Common.Brokerages
     {
         private readonly ClearStreetBrokerageModel _brokerageModel = new();
 
-        // Equity, Option and IndexOption accept every order type Clear Street knows.
+        // Equity takes every order type Clear Street knows, an option takes only market and limit.
         [TestCase(SecurityType.Equity, OrderType.Market)]
         [TestCase(SecurityType.Equity, OrderType.Limit)]
         [TestCase(SecurityType.Equity, OrderType.StopMarket)]
@@ -35,14 +35,8 @@ namespace QuantConnect.Tests.Common.Brokerages
         [TestCase(SecurityType.Equity, OrderType.TrailingStop)]
         [TestCase(SecurityType.Option, OrderType.Market)]
         [TestCase(SecurityType.Option, OrderType.Limit)]
-        [TestCase(SecurityType.Option, OrderType.StopMarket)]
-        [TestCase(SecurityType.Option, OrderType.StopLimit)]
-        [TestCase(SecurityType.Option, OrderType.TrailingStop)]
         [TestCase(SecurityType.IndexOption, OrderType.Market)]
         [TestCase(SecurityType.IndexOption, OrderType.Limit)]
-        [TestCase(SecurityType.IndexOption, OrderType.StopMarket)]
-        [TestCase(SecurityType.IndexOption, OrderType.StopLimit)]
-        [TestCase(SecurityType.IndexOption, OrderType.TrailingStop)]
         public void CanSubmitOrderValidSecurityAndOrderTypeReturnsTrue(SecurityType securityType, OrderType orderType)
         {
             var security = GetSecurityForType(securityType);
@@ -81,6 +75,14 @@ namespace QuantConnect.Tests.Common.Brokerages
         [TestCase(SecurityType.Option, OrderType.ComboLimit)]
         [TestCase(SecurityType.IndexOption, OrderType.MarketOnOpen)]
         [TestCase(SecurityType.IndexOption, OrderType.ComboMarket)]
+        // Clear Street answers "order_type Stop is not allowed for security_type Option" on a stop
+        // order of an option, so the model has to stop them before they are sent.
+        [TestCase(SecurityType.Option, OrderType.StopMarket)]
+        [TestCase(SecurityType.Option, OrderType.StopLimit)]
+        [TestCase(SecurityType.Option, OrderType.TrailingStop)]
+        [TestCase(SecurityType.IndexOption, OrderType.StopMarket)]
+        [TestCase(SecurityType.IndexOption, OrderType.StopLimit)]
+        [TestCase(SecurityType.IndexOption, OrderType.TrailingStop)]
         public void CanSubmitOrderUnsupportedOrderTypeReturnsFalse(SecurityType securityType, OrderType orderType)
         {
             var security = GetSecurityForType(securityType);


### PR DESCRIPTION
#### Description
Clear Street takes only market and limit orders on options. `ClearStreetBrokerageModel.CanSubmitOrder` let a stop, stop limit or trailing stop order through for `Option` and `IndexOption`, so the order left Lean and came back rejected by the API. The model now keeps the full order type list for equity and uses a market/limit list for options.

Live answer before the fix:

```
[POST] https://api.clearstreet.com/v1/accounts/{account_id}/orders
Body:   [{"order_type":"STOP","stop_price":"3.90","symbol":"BRKB  260904C00502500","side":"BUY","quantity":"1","time_in_force":"GOOD_TILL_CANCEL"}]
Answer: {"error":{"code":422,"message":"order_type Stop is not allowed for security_type Option"}}
```

The same 422 comes back for `StopLimit` and `TrailingStop`. Equity is not affected.

#### Related PR(s)
N/A

#### Related Issue
N/A

#### Motivation and Context
An option stop order was accepted by Lean and killed by the brokerage, so the algorithm only learned about it from an Invalid order event after the round trip. The model now says no before the order is sent.

#### Requires Documentation Change
No.

#### How Has This Been Tested?
`ClearStreetBrokerageModelTests`:
- `CanSubmitOrderValidSecurityAndOrderTypeReturnsTrue` keeps Market and Limit for `Option` and `IndexOption`, and every order type for `Equity`.
- `CanSubmitOrderUnsupportedOrderTypeReturnsFalse` gained six cases: `StopMarket`, `StopLimit` and `TrailingStop` for `Option` and `IndexOption`.

The 422 above comes from a live Clear Street account (account 125046) while running the brokerage plugin order tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
