### PR TITLE
Fix pandas conversion of dynamic data with heterogeneous properties

### DIFF
--- a/Common/Python/PandasData.cs
+++ b/Common/Python/PandasData.cs
@@ -194,13 +194,7 @@ namespace QuantConnect.Python
                     // if this is a PythonData instance we add in '__typename' which we don't want into the data frame
                     && !x.Key.StartsWith("__", StringComparison.InvariantCulture)))
                 {
-                    // Dynamic data instances might not all have the same properties,
-                    // so add series for new properties as they appear
-                    if (!_series.TryGetValue(kvp.Key, out var serie))
-                    {
-                        _series[kvp.Key] = serie = new Serie(withTimeIndex: !_timeAsColumn);
-                    }
-                    serie.Add(endTime, kvp.Value, overrideValues);
+                    AddToSeries(kvp.Key, endTime, kvp.Value, overrideValues);
                 }
             }
         }
@@ -685,7 +679,9 @@ namespace QuantConnect.Python
         {
             if (!_series.TryGetValue(key, out var serie))
             {
-                throw new ArgumentException($"PandasData.AddToSeries(): {Messages.PandasData.KeyNotFoundInSeries(key)}");
+                // Dynamic data instances might not all have the same properties,
+                // so add series for new properties as they appear
+                _series[key] = serie = new Serie(withTimeIndex: !_timeAsColumn);
             }
 
             serie.Add(time, input, overrideValues);

--- a/Common/Python/PandasData.cs
+++ b/Common/Python/PandasData.cs
@@ -75,7 +75,6 @@ namespace QuantConnect.Python
         private readonly Dictionary<string, Serie> _series;
         // time of each row added, used to fill the series missing a row so all have one value per row
         private readonly List<DateTime> _rowTimes = new();
-        private int _touchedSeriesCount;
 
         private readonly Dictionary<Type, List<DataTypeMember>> _members = new();
 
@@ -180,37 +179,37 @@ namespace QuantConnect.Python
             {
                 _rowTimes.Add(endTime);
             }
-            _touchedSeriesCount = 0;
+            var touchedSeriesCount = 0;
 
             var typeMembers = GetInstanceDataTypeMembers(data);
 
             if (_isBaseData && _timeAsColumn)
             {
-                AddToSeries("time", endTime, endTime, overrideValues);
+                touchedSeriesCount += AddToSeries("time", endTime, endTime, overrideValues);
             }
 
-            AddMembersData(data, typeMembers, endTime, overrideValues);
+            touchedSeriesCount += AddMembersData(data, typeMembers, endTime, overrideValues);
 
             if (data is DynamicData dynamicData)
             {
                 var storage = dynamicData.GetStorageDictionary();
                 var value = dynamicData.Value;
-                AddToSeries("value", endTime, value, overrideValues);
+                touchedSeriesCount += AddToSeries("value", endTime, value, overrideValues);
 
                 foreach (var kvp in storage.Where(x => x.Key != "value"
                     // if this is a PythonData instance we add in '__typename' which we don't want into the data frame
                     && !x.Key.StartsWith("__", StringComparison.InvariantCulture)))
                 {
-                    AddToSeries(kvp.Key, endTime, kvp.Value, overrideValues);
+                    touchedSeriesCount += AddToSeries(kvp.Key, endTime, kvp.Value, overrideValues);
                 }
             }
 
             // fill the series this data point didn't touch, only scanning when there is any
-            if (_touchedSeriesCount != _series.Count)
+            if (touchedSeriesCount != _series.Count)
             {
                 foreach (var serie in _series.Values)
                 {
-                    FillMissingRows(serie, _rowTimes.Count);
+                    serie.FillMissingRows(_rowTimes, _rowTimes.Count);
                 }
             }
         }
@@ -221,23 +220,16 @@ namespace QuantConnect.Python
         private Serie CreateSerie(int rowCount)
         {
             var serie = new Serie(withTimeIndex: !_timeAsColumn);
-            FillMissingRows(serie, rowCount);
+            serie.FillMissingRows(_rowTimes, rowCount);
             return serie;
         }
 
         /// <summary>
-        /// Appends missing values to the series until it has the given number of rows
+        /// Returns the number of series touched
         /// </summary>
-        private void FillMissingRows(Serie serie, int rowCount)
+        private int AddMemberToSeries(object instance, DateTime endTime, DataTypeMember member, bool overrideValues)
         {
-            for (var i = serie.Values.Count; i < rowCount; i++)
-            {
-                serie.Add(_rowTimes[i], null, overrideValues: false);
-            }
-        }
-
-        private void AddMemberToSeries(object instance, DateTime endTime, DataTypeMember member, bool overrideValues)
-        {
+            var touchedSeriesCount = 0;
             var baseName = (string)null;
             var tick = member.IsTickProperty ? instance as Tick : null;
             if (tick != null && member.IsTickLastPrice && tick.TickType == TickType.OpenInterest)
@@ -272,12 +264,13 @@ namespace QuantConnect.Python
                         var nullValueKey = tick.TickType != TickType.OpenInterest
                             ? member.GetMemberName("OpenInterest")
                             : member.GetMemberName();
-                        AddToSeries(nullValueKey, endTime, null, overrideValues);
+                        touchedSeriesCount += AddToSeries(nullValueKey, endTime, null, overrideValues);
                     }
                 }
             }
 
-            AddToSeries(key, endTime, value, overrideValues);
+            touchedSeriesCount += AddToSeries(key, endTime, value, overrideValues);
+            return touchedSeriesCount;
         }
 
         /// <summary>
@@ -646,23 +639,25 @@ namespace QuantConnect.Python
         /// Adds the member value to the corresponding series, making sure unwrapped values a properly added
         /// by checking the children members and adding their values to their own series
         /// </summary>
-        private void AddMembersData(object instance, IEnumerable<DataTypeMember> members, DateTime endTime, bool overrideValues)
+        private int AddMembersData(object instance, IEnumerable<DataTypeMember> members, DateTime endTime, bool overrideValues)
         {
+            var touchedSeriesCount = 0;
             foreach (var member in members)
             {
                 if (!member.ShouldBeUnwrapped)
                 {
-                    AddMemberToSeries(instance, endTime, member, overrideValues);
+                    touchedSeriesCount += AddMemberToSeries(instance, endTime, member, overrideValues);
                 }
                 else
                 {
                     var memberValue = member.GetValue(instance);
                     if (memberValue != null)
                     {
-                        AddMembersData(memberValue, member.Children, endTime, overrideValues);
+                        touchedSeriesCount += AddMembersData(memberValue, member.Children, endTime, overrideValues);
                     }
                 }
             }
+            return touchedSeriesCount;
         }
 
         /// <summary>
@@ -720,7 +715,7 @@ namespace QuantConnect.Python
         /// <param name="key">The key of the value to get</param>
         /// <param name="time"><see cref="DateTime"/> object to add to the value associated with the specific key</param>
         /// <param name="input"><see cref="Object"/> to add to the value associated with the specific key. Can be null.</param>
-        private void AddToSeries(string key, DateTime time, object input, bool overrideValues)
+        private int AddToSeries(string key, DateTime time, object input, bool overrideValues)
         {
             if (!_series.TryGetValue(key, out var serie))
             {
@@ -730,7 +725,8 @@ namespace QuantConnect.Python
             }
 
             serie.Add(time, input, overrideValues);
-            _touchedSeriesCount++;
+            // the number of series touched, for the callers to accumulate
+            return 1;
         }
 
         private class Serie
@@ -748,6 +744,17 @@ namespace QuantConnect.Python
                 if (withTimeIndex)
                 {
                     Times = new();
+                }
+            }
+
+            /// <summary>
+            /// Appends missing values until the series has the given number of rows
+            /// </summary>
+            public void FillMissingRows(List<DateTime> rowTimes, int rowCount)
+            {
+                for (var i = Values.Count; i < rowCount; i++)
+                {
+                    Add(rowTimes[i], null, overrideValues: false);
                 }
             }
 

--- a/Common/Python/PandasData.cs
+++ b/Common/Python/PandasData.cs
@@ -73,6 +73,9 @@ namespace QuantConnect.Python
         private readonly bool _isBaseData;
         private readonly bool _timeAsColumn;
         private readonly Dictionary<string, Serie> _series;
+        // time of each row added, used to fill the series missing a row so all have one value per row
+        private readonly List<DateTime> _rowTimes = new();
+        private int _touchedSeriesCount;
 
         private readonly Dictionary<Type, List<DataTypeMember>> _members = new();
 
@@ -170,16 +173,20 @@ namespace QuantConnect.Python
                 return;
             }
 
+            var endTime = _isBaseData ? ((IBaseData)data).EndTime : default;
+
+            // same as Serie.Add, overriding the values at the last row time doesn't add a new row
+            if (!overrideValues || _timeAsColumn || _rowTimes.Count == 0 || _rowTimes[^1] != endTime)
+            {
+                _rowTimes.Add(endTime);
+            }
+            _touchedSeriesCount = 0;
+
             var typeMembers = GetInstanceDataTypeMembers(data);
 
-            var endTime = default(DateTime);
-            if (_isBaseData)
+            if (_isBaseData && _timeAsColumn)
             {
-                endTime = ((IBaseData)data).EndTime;
-                if (_timeAsColumn)
-                {
-                    AddToSeries("time", endTime, endTime, overrideValues);
-                }
+                AddToSeries("time", endTime, endTime, overrideValues);
             }
 
             AddMembersData(data, typeMembers, endTime, overrideValues);
@@ -196,6 +203,36 @@ namespace QuantConnect.Python
                 {
                     AddToSeries(kvp.Key, endTime, kvp.Value, overrideValues);
                 }
+            }
+
+            // fill the series this data point didn't touch, only scanning when there is any
+            if (_touchedSeriesCount != _series.Count)
+            {
+                foreach (var serie in _series.Values)
+                {
+                    FillMissingRows(serie, _rowTimes.Count);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates a series filled with missing values for the given number of rows
+        /// </summary>
+        private Serie CreateSerie(int rowCount)
+        {
+            var serie = new Serie(withTimeIndex: !_timeAsColumn);
+            FillMissingRows(serie, rowCount);
+            return serie;
+        }
+
+        /// <summary>
+        /// Appends missing values to the series until it has the given number of rows
+        /// </summary>
+        private void FillMissingRows(Serie serie, int rowCount)
+        {
+            for (var i = serie.Values.Count; i < rowCount; i++)
+            {
+                serie.Add(_rowTimes[i], null, overrideValues: false);
             }
         }
 
@@ -358,6 +395,7 @@ namespace QuantConnect.Python
                 pyDict.SetItem(pyKey, series);
             }
             _series.Clear();
+            _rowTimes.Clear();
             foreach (var kvp in indexCache)
             {
                 kvp.Value.Dispose();
@@ -393,6 +431,7 @@ namespace QuantConnect.Python
             using var namesDic = Py.kw("name", _level1Names[0]);
             using var index = _indexFactory.Invoke(new[] { list }, namesDic);
 
+            using var none = PyObject.None;
             var valuesPerSeries = new Dictionary<string, PyList>();
             var seriesToSkip = new Dictionary<string, bool>();
             var dataPointCount = 0;
@@ -417,14 +456,11 @@ namespace QuantConnect.Python
 
                     if (!valuesPerSeries.TryGetValue(kvp.Key, out PyList value))
                     {
-                        // Adds pandas.Series value keyed by the column name.
-                        // Back fill with missing values for the previous data points that don't have this series,
-                        // like dynamic data instances that don't all have the same properties,
-                        // so that every column has one value per symbol in the index
+                        // new column: back fill the previous symbols with missing values so it lines up with the index
                         value = valuesPerSeries[kvp.Key] = new PyList();
                         for (var i = 0; i < dataPointCount; i++)
                         {
-                            value.Append(PyObject.None);
+                            value.Append(none);
                         }
                     }
 
@@ -436,7 +472,7 @@ namespace QuantConnect.Python
                     }
                     else
                     {
-                        value.Append(PyObject.None);
+                        value.Append(none);
                     }
 
                     contributedSeriesCount++;
@@ -444,16 +480,14 @@ namespace QuantConnect.Python
 
                 dataPointCount++;
 
-                // Fill with missing values the series this data point doesn't have.
-                // Only scan for them when this data point didn't contribute to every known series,
-                // so data points with homogeneous series, the common case, don't pay for the scan
+                // fill the columns this symbol doesn't have, only scanning when there is any
                 if (contributedSeriesCount != valuesPerSeries.Count)
                 {
                     foreach (var kvp in valuesPerSeries)
                     {
                         if (!pandasData._series.ContainsKey(kvp.Key))
                         {
-                            kvp.Value.Append(PyObject.None);
+                            kvp.Value.Append(none);
                         }
                     }
                 }
@@ -518,7 +552,11 @@ namespace QuantConnect.Python
 
                 foreach (var columnName in columnNames)
                 {
-                    _series.TryAdd(columnName, new Serie(withTimeIndex: !_timeAsColumn));
+                    if (!_series.ContainsKey(columnName))
+                    {
+                        // the current row is added right after, so only the previous ones are filled
+                        _series[columnName] = CreateSerie(_rowTimes.Count - 1);
+                    }
                 }
             }
 
@@ -687,12 +725,13 @@ namespace QuantConnect.Python
         {
             if (!_series.TryGetValue(key, out var serie))
             {
-                // Dynamic data instances might not all have the same properties,
-                // so add series for new properties as they appear
-                _series[key] = serie = new Serie(withTimeIndex: !_timeAsColumn);
+                // new dynamic data property: fill the previous rows and append the current one, never overriding a filled row
+                _series[key] = serie = CreateSerie(_rowTimes.Count - 1);
+                overrideValues = false;
             }
 
             serie.Add(time, input, overrideValues);
+            _touchedSeriesCount++;
         }
 
         private class Serie

--- a/Common/Python/PandasData.cs
+++ b/Common/Python/PandasData.cs
@@ -496,17 +496,16 @@ namespace QuantConnect.Python
             using var pyDict = new PyDict();
             foreach (var kvp in valuesPerSeries)
             {
+                using var value = kvp.Value;
                 if (seriesToSkip.TryGetValue(kvp.Key, out var skip) && skip)
                 {
                     continue;
                 }
 
-                using var series = _seriesFactory.Invoke(kvp.Value, index);
+                using var series = _seriesFactory.Invoke(value, index);
                 using var pyStrKey = kvp.Key.ToPython();
                 using var pyKey = _pandasColumn.Invoke(pyStrKey);
                 pyDict.SetItem(pyKey, series);
-
-                kvp.Value.Dispose();
             }
             var result = _dataFrameFactory.Invoke(pyDict);
 

--- a/Common/Python/PandasData.cs
+++ b/Common/Python/PandasData.cs
@@ -194,7 +194,13 @@ namespace QuantConnect.Python
                     // if this is a PythonData instance we add in '__typename' which we don't want into the data frame
                     && !x.Key.StartsWith("__", StringComparison.InvariantCulture)))
                 {
-                    AddToSeries(kvp.Key, endTime, kvp.Value, overrideValues);
+                    // Dynamic data instances might not all have the same properties,
+                    // so add series for new properties as they appear
+                    if (!_series.TryGetValue(kvp.Key, out var serie))
+                    {
+                        _series[kvp.Key] = serie = new Serie(withTimeIndex: !_timeAsColumn);
+                    }
+                    serie.Add(endTime, kvp.Value, overrideValues);
                 }
             }
         }
@@ -395,6 +401,7 @@ namespace QuantConnect.Python
 
             var valuesPerSeries = new Dictionary<string, PyList>();
             var seriesToSkip = new Dictionary<string, bool>();
+            var dataPointCount = 0;
             foreach (var pandasData in pandasDatas)
             {
                 foreach (var kvp in pandasData._series)
@@ -415,8 +422,15 @@ namespace QuantConnect.Python
 
                     if (!valuesPerSeries.TryGetValue(kvp.Key, out PyList value))
                     {
-                        // Adds pandas.Series value keyed by the column name
+                        // Adds pandas.Series value keyed by the column name.
+                        // Back fill with missing values for the previous data points that don't have this series,
+                        // like dynamic data instances that don't all have the same properties,
+                        // so that every column has one value per symbol in the index
                         value = valuesPerSeries[kvp.Key] = new PyList();
+                        for (var i = 0; i < dataPointCount; i++)
+                        {
+                            value.Append(PyObject.None);
+                        }
                     }
 
                     if (kvp.Value.Values.Count > 0)
@@ -428,6 +442,17 @@ namespace QuantConnect.Python
                     else
                     {
                         value.Append(PyObject.None);
+                    }
+                }
+
+                dataPointCount++;
+
+                // Fill with missing values the series this data point doesn't have
+                foreach (var kvp in valuesPerSeries)
+                {
+                    if (!pandasData._series.ContainsKey(kvp.Key))
+                    {
+                        kvp.Value.Append(PyObject.None);
                     }
                 }
             }

--- a/Common/Python/PandasData.cs
+++ b/Common/Python/PandasData.cs
@@ -215,16 +215,6 @@ namespace QuantConnect.Python
         }
 
         /// <summary>
-        /// Creates a series filled with missing values for the given number of rows
-        /// </summary>
-        private Serie CreateSerie(int rowCount)
-        {
-            var serie = new Serie(withTimeIndex: !_timeAsColumn);
-            serie.FillMissingRows(_rowTimes, rowCount);
-            return serie;
-        }
-
-        /// <summary>
         /// Returns the number of series touched
         /// </summary>
         private int AddMemberToSeries(object instance, DateTime endTime, DataTypeMember member, bool overrideValues)
@@ -547,7 +537,7 @@ namespace QuantConnect.Python
                     if (!_series.ContainsKey(columnName))
                     {
                         // the current row is added right after, so only the previous ones are filled
-                        _series[columnName] = CreateSerie(_rowTimes.Count - 1);
+                        _series[columnName] = Serie.Create(!_timeAsColumn, _rowTimes, _rowTimes.Count - 1);
                     }
                 }
             }
@@ -720,7 +710,7 @@ namespace QuantConnect.Python
             if (!_series.TryGetValue(key, out var serie))
             {
                 // new dynamic data property: fill the previous rows and append the current one, never overriding a filled row
-                _series[key] = serie = CreateSerie(_rowTimes.Count - 1);
+                _series[key] = serie = Serie.Create(!_timeAsColumn, _rowTimes, _rowTimes.Count - 1);
                 overrideValues = false;
             }
 
@@ -745,6 +735,16 @@ namespace QuantConnect.Python
                 {
                     Times = new();
                 }
+            }
+
+            /// <summary>
+            /// Creates a series filled with missing values for the given number of rows
+            /// </summary>
+            public static Serie Create(bool withTimeIndex, List<DateTime> rowTimes, int rowCount)
+            {
+                var serie = new Serie(withTimeIndex);
+                serie.FillMissingRows(rowTimes, rowCount);
+                return serie;
             }
 
             /// <summary>

--- a/Common/Python/PandasData.cs
+++ b/Common/Python/PandasData.cs
@@ -398,6 +398,7 @@ namespace QuantConnect.Python
             var dataPointCount = 0;
             foreach (var pandasData in pandasDatas)
             {
+                var contributedSeriesCount = 0;
                 foreach (var kvp in pandasData._series)
                 {
                     if (skipTimesColumn && kvp.Key == "time")
@@ -437,16 +438,23 @@ namespace QuantConnect.Python
                     {
                         value.Append(PyObject.None);
                     }
+
+                    contributedSeriesCount++;
                 }
 
                 dataPointCount++;
 
-                // Fill with missing values the series this data point doesn't have
-                foreach (var kvp in valuesPerSeries)
+                // Fill with missing values the series this data point doesn't have.
+                // Only scan for them when this data point didn't contribute to every known series,
+                // so data points with homogeneous series, the common case, don't pay for the scan
+                if (contributedSeriesCount != valuesPerSeries.Count)
                 {
-                    if (!pandasData._series.ContainsKey(kvp.Key))
+                    foreach (var kvp in valuesPerSeries)
                     {
-                        kvp.Value.Append(PyObject.None);
+                        if (!pandasData._series.ContainsKey(kvp.Key))
+                        {
+                            kvp.Value.Append(PyObject.None);
+                        }
                     }
                 }
             }

--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -302,6 +302,86 @@ namespace QuantConnect.Tests.Python
             }
         }
 
+        [Test]
+        public void HandlesDynamicDataWithHeterogeneousPropertiesAtTheSameTime([Values] bool propertyOnlyInLastDataPoint)
+        {
+            var converter = new PandasConverter();
+            var time = new DateTime(2020, 1, 2);
+            var data = CreateDynamicDataWithHeterogeneousProperties(time, time, propertyOnlyInLastDataPoint);
+
+            dynamic dataFrame = converter.GetDataFrame(data);
+
+            using (Py.GIL())
+            {
+                var count = dataFrame.__len__().AsManagedObject(typeof(int));
+                Assert.AreEqual(2, count);
+
+                Assert.Multiple(() =>
+                {
+                    CollectionAssert.AreEqual(new[] { 1d, 2d }, dataFrame["value"].AsManagedObject(typeof(double[])));
+                    CollectionAssert.AreEqual(new[] { 10d, 20d }, dataFrame["factor_a"].AsManagedObject(typeof(double[])));
+
+                    // The data point without the property must not get the value of the one that has it,
+                    // even though both share the same index
+                    var factorB = (double[])dataFrame["factor_b"].AsManagedObject(typeof(double[]));
+                    var expectedFactorB = propertyOnlyInLastDataPoint ? new[] { double.NaN, 30d } : new[] { 30d, double.NaN };
+                    CollectionAssert.AreEqual(expectedFactorB, factorB);
+                });
+            }
+        }
+
+        [Test]
+        public void FlattensSingleSymbolBaseDataCollectionOfDynamicDataWithHeterogeneousProperties([Values] bool propertyOnlyInLastDataPoint)
+        {
+            var converter = new PandasConverter();
+            var data = new[]
+            {
+                new EnumerableData
+                {
+                    Data = CreateDynamicDataWithHeterogeneousProperties(new DateTime(2020, 1, 2), new DateTime(2020, 1, 3), propertyOnlyInLastDataPoint)
+                        .Cast<BaseData>().ToList(),
+                    Symbol = Symbols.IBM,
+                    Time = new DateTime(2020, 1, 1)
+                }
+            };
+
+            dynamic dataFrame = converter.GetDataFrame(data, flatten: true);
+
+            using (Py.GIL())
+            {
+                var count = dataFrame.__len__().AsManagedObject(typeof(int));
+                Assert.AreEqual(2, count);
+                AssertFlattenBaseDataCollectionDataFrameTimes(data, dataFrame);
+
+                Assert.Multiple(() =>
+                {
+                    CollectionAssert.AreEqual(new[] { 1d, 2d }, dataFrame["value"].AsManagedObject(typeof(double[])));
+                    CollectionAssert.AreEqual(new[] { 10d, 20d }, dataFrame["factor_a"].AsManagedObject(typeof(double[])));
+
+                    var factorB = (double[])dataFrame["factor_b"].AsManagedObject(typeof(double[]));
+                    var expectedFactorB = propertyOnlyInLastDataPoint ? new[] { double.NaN, 30d } : new[] { 30d, double.NaN };
+                    CollectionAssert.AreEqual(expectedFactorB, factorB);
+                });
+            }
+        }
+
+        /// <summary>
+        /// Two data points for the same symbol where only one of them has the "factor_b" property
+        /// </summary>
+        private static List<CustomData> CreateDynamicDataWithHeterogeneousProperties(DateTime firstTime, DateTime secondTime,
+            bool propertyOnlyInLastDataPoint)
+        {
+            var firstDataPoint = new CustomData { Symbol = Symbols.IBM, Time = firstTime, Value = 1m };
+            firstDataPoint.SetProperty("factor_a", 10m);
+
+            var secondDataPoint = new CustomData { Symbol = Symbols.IBM, Time = secondTime, Value = 2m };
+            secondDataPoint.SetProperty("factor_a", 20m);
+
+            (propertyOnlyInLastDataPoint ? secondDataPoint : firstDataPoint).SetProperty("factor_b", 30m);
+
+            return new List<CustomData> { firstDataPoint, secondDataPoint };
+        }
+
         private static void AssertFlattenBaseDataCollectionDataFrameTimes(EnumerableData[] data, dynamic dataFrame)
         {
             // For base data collections, the end time of each data point is added as a column

--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -331,6 +331,53 @@ namespace QuantConnect.Tests.Python
         }
 
         [Test]
+        public void HandlesDynamicDataWithPropertyMissingInAMiddleDataPoint()
+        {
+            var converter = new PandasConverter();
+
+            // factor_a has a value at all 4 times, factor_b is missing at the 3rd one
+            var factorAValues = new[] { 10d, 20d, 30d, 40d };
+            var factorBValues = new double?[] { 100d, 200d, null, 400d };
+
+            var data = new List<CustomData>();
+            for (var i = 0; i < factorAValues.Length; i++)
+            {
+                var dataPoint = new CustomData { Symbol = Symbols.IBM, Time = new DateTime(2020, 1, 2).AddDays(i), Value = i + 1 };
+                dataPoint.SetProperty("factor_a", (decimal)factorAValues[i]);
+                if (factorBValues[i].HasValue)
+                {
+                    dataPoint.SetProperty("factor_b", (decimal)factorBValues[i].Value);
+                }
+                data.Add(dataPoint);
+            }
+
+            dynamic dataFrame = converter.GetDataFrame(data);
+
+            using (Py.GIL())
+            {
+                var count = dataFrame.__len__().AsManagedObject(typeof(int));
+                Assert.AreEqual(4, count);
+
+                Assert.Multiple(() =>
+                {
+                    var times = new DateTime[count];
+                    for (var i = 0; i < count; i++)
+                    {
+                        times[i] = (DateTime)dataFrame.index.get_level_values(1)[i].AsManagedObject(typeof(DateTime));
+                    }
+                    CollectionAssert.AreEqual(data.Select(x => x.EndTime), times);
+
+                    CollectionAssert.AreEqual(new[] { 1d, 2d, 3d, 4d }, dataFrame["value"].AsManagedObject(typeof(double[])));
+                    CollectionAssert.AreEqual(factorAValues, dataFrame["factor_a"].AsManagedObject(typeof(double[])));
+
+                    // the data point without the property gets a missing value in its row
+                    var factorB = (double[])dataFrame["factor_b"].AsManagedObject(typeof(double[]));
+                    CollectionAssert.AreEqual(new[] { 100d, 200d, double.NaN, 400d }, factorB);
+                });
+            }
+        }
+
+        [Test]
         public void FlattensSingleSymbolBaseDataCollectionOfDynamicDataWithHeterogeneousProperties([Values] bool propertyOnlyInLastDataPoint)
         {
             var converter = new PandasConverter();

--- a/Tests/Python/PandasConverterTests.cs
+++ b/Tests/Python/PandasConverterTests.cs
@@ -183,6 +183,125 @@ namespace QuantConnect.Tests.Python
             }
         }
 
+        [Test]
+        public void FlattensBaseDataCollectionOfDynamicDataWithHeterogeneousProperties()
+        {
+            var converter = new PandasConverter();
+            var date = new DateTime(2020, 1, 2);
+
+            // Mimics universe data types like FactorsUniverse, where each constituent is a DynamicData
+            // instance carrying its own set of dynamic properties
+            var ibmData = new CustomData { Symbol = Symbols.IBM, Time = date, Value = 1m };
+            ibmData.SetProperty("factor_a", 10m);
+            ibmData.SetProperty("factor_b", 20m);
+
+            var spyData = new CustomData { Symbol = Symbols.SPY, Time = date, Value = 2m };
+            spyData.SetProperty("factor_a", 30m);
+
+            var unlinkedData = new CustomData
+            {
+                Symbol = Symbol.Create("UNLINKED", SecurityType.Base, Market.USA),
+                Time = date,
+                Value = 3m
+            };
+            unlinkedData.SetProperty("factor_c", 40m);
+
+            var data = new[]
+            {
+                new EnumerableData
+                {
+                    Data = new List<BaseData> { ibmData, spyData, unlinkedData },
+                    Symbol = Symbol.Create("universe", SecurityType.Base, Market.USA),
+                    Time = date
+                }
+            };
+
+            dynamic dataFrame = converter.GetDataFrame(data, flatten: true);
+
+            using (Py.GIL())
+            {
+                Assert.IsFalse(dataFrame.empty.AsManagedObject(typeof(bool)));
+
+                var indexNames = dataFrame.index.names.AsManagedObject(typeof(string[]));
+                CollectionAssert.AreEqual(new[] { "time", "symbol" }, indexNames);
+
+                var count = dataFrame.__len__().AsManagedObject(typeof(int));
+                Assert.AreEqual(3, count);
+
+                var columnNames = new List<string>();
+                foreach (var column in dataFrame.columns)
+                {
+                    columnNames.Add(column.__str__().AsManagedObject(typeof(string)));
+                }
+                CollectionAssert.IsSubsetOf(new[] { "value", "factor_a", "factor_b", "factor_c" }, columnNames);
+
+                var symbols = dataFrame.index.get_level_values(1);
+                Assert.Multiple(() =>
+                {
+                    for (var i = 0; i < 3; i++)
+                    {
+                        Assert.AreEqual(data[0].Data[i].Symbol, symbols[i].AsManagedObject(typeof(Symbol)));
+                    }
+
+                    CollectionAssert.AreEqual(new[] { 1d, 2d, 3d }, dataFrame["value"].AsManagedObject(typeof(double[])));
+
+                    // Constituents without a value for a given dynamic property get a missing value in that column
+                    var factorA = (double[])dataFrame["factor_a"].AsManagedObject(typeof(double[]));
+                    Assert.AreEqual(10d, factorA[0]);
+                    Assert.AreEqual(30d, factorA[1]);
+                    Assert.IsTrue(double.IsNaN(factorA[2]));
+
+                    var factorB = (double[])dataFrame["factor_b"].AsManagedObject(typeof(double[]));
+                    Assert.AreEqual(20d, factorB[0]);
+                    Assert.IsTrue(double.IsNaN(factorB[1]));
+                    Assert.IsTrue(double.IsNaN(factorB[2]));
+
+                    var factorC = (double[])dataFrame["factor_c"].AsManagedObject(typeof(double[]));
+                    Assert.IsTrue(double.IsNaN(factorC[0]));
+                    Assert.IsTrue(double.IsNaN(factorC[1]));
+                    Assert.AreEqual(40d, factorC[2]);
+                });
+            }
+        }
+
+        [Test]
+        public void HandlesDynamicDataWithPropertiesAddedInLaterDataPoints()
+        {
+            var converter = new PandasConverter();
+
+            // Mimics data types like Factors, where a dynamic property can be missing in the
+            // first data points and appear later in the series
+            var firstDataPoint = new CustomData { Symbol = Symbols.IBM, Time = new DateTime(2020, 1, 2), Value = 1m };
+            firstDataPoint.SetProperty("factor_a", 10m);
+
+            var secondDataPoint = new CustomData { Symbol = Symbols.IBM, Time = new DateTime(2020, 1, 3), Value = 2m };
+            secondDataPoint.SetProperty("factor_a", 20m);
+            secondDataPoint.SetProperty("factor_b", 30m);
+
+            var data = new List<CustomData> { firstDataPoint, secondDataPoint };
+
+            dynamic dataFrame = converter.GetDataFrame(data);
+
+            using (Py.GIL())
+            {
+                Assert.IsFalse(dataFrame.empty.AsManagedObject(typeof(bool)));
+
+                var count = dataFrame.__len__().AsManagedObject(typeof(int));
+                Assert.AreEqual(2, count);
+
+                Assert.Multiple(() =>
+                {
+                    CollectionAssert.AreEqual(new[] { 1d, 2d }, dataFrame["value"].AsManagedObject(typeof(double[])));
+                    CollectionAssert.AreEqual(new[] { 10d, 20d }, dataFrame["factor_a"].AsManagedObject(typeof(double[])));
+
+                    // The data point without a value for the property gets a missing value in that column
+                    var factorB = (double[])dataFrame["factor_b"].AsManagedObject(typeof(double[]));
+                    Assert.IsTrue(double.IsNaN(factorB[0]));
+                    Assert.AreEqual(30d, factorB[1]);
+                });
+            }
+        }
+
         private static void AssertFlattenBaseDataCollectionDataFrameTimes(EnumerableData[] data, dynamic dataFrame)
         {
             // For base data collections, the end time of each data point is added as a column


### PR DESCRIPTION
#### Description

`QuantBook.UniverseHistory` with `flatten=True` fails when the universe constituents are `DynamicData` instances that don't all carry the same properties, e.g. per-security rows carrying security-specific factors plus a market-wide row carrying a different one:

```
ValueError: Length of values (1) does not match length of index (504)
```

The same call without `flatten` works, one row per day with the constituent objects in the cell:

```
symbol                        time
MY-UNIVERSE.MyFactorsData 2S  2026-08-01    [MyFactorsData: AAPL, MyFactorsData: SPY, MyF...
                              2026-08-02    [MyFactorsData: AAPL, MyFactorsData: SPY, MyF...
```

With the fix, `flatten=True` returns one row per constituent, with `NaN` for the properties a row doesn't carry:

```
                              factor_a  market_factor
time       symbol
2026-08-01 AAPL R735QTJ8XC9X  0.019643            NaN
           SPY R735QTJ8XC9X  -0.004292            NaN
           $MARKET 2S              NaN           3.78
2026-08-02 AAPL R735QTJ8XC9X  0.013058            NaN
...
```

Cause: `DynamicData` columns come from each instance's storage dictionary, so data points can contribute different column sets, which the pandas conversion assumed were homogeneous.

`PandasData` stores a symbol's data as one series per column and both data frame builders assume every series has exactly one entry per row. Everything in this PR exists to restore that guarantee for `DynamicData`, filling the missing entries with `NaN`.

The fix:
- `PandasData.ToPandasDataFrame(IEnumerable<PandasData>, ...)` (multi-symbol frame) back-fills missing values for the symbols that don't have a given series, so every column stays aligned with the symbol index. The scan only runs for symbols that don't have every known series, so homogeneous data doesn't pay for it.
- `PandasData` now keeps every series aligned with the rows added. A series created on demand for a property that first appears in a later data point (previously `ArgumentException: <name> key does not exist in series dictionary`) is filled with missing values for the previous rows, and the series a data point doesn't have are filled for that row. Same lazy scan as above.

The second point also fixes two bugs already in master for a series that stops having a property:
- Same symbol, same `EndTime`: the value silently broadcasts onto the rows that never had the property.
- Flattened single-symbol collection: `ValueError: Length of values (1) does not match length of index (2)`.

#### Related Issue

N/A

#### Motivation and Context

Universe and history requests for dynamic data types (custom C# `DynamicData` and `PythonData`) with per-row properties should produce `NaN` for the properties a row doesn't carry instead of crashing or returning wrong values.

#### Requires Documentation Change

No

#### How Has This Been Tested?

- `PandasConverterTests.FlattensBaseDataCollectionOfDynamicDataWithHeterogeneousProperties`: flattens a universe collection with 3 constituents carrying different properties. Asserts row count, index names and `NaN` placement. Reproduces the `ValueError` without the fix.
- `PandasConverterTests.HandlesDynamicDataWithPropertiesAddedInLaterDataPoints`: a property first appears in the second data point of a series. Asserts values and `NaN` for the first point. Reproduces the `ArgumentException` without the fix.
- `PandasConverterTests.HandlesDynamicDataWithHeterogeneousPropertiesAtTheSameTime`: two data points at the same `EndTime`, the property present in only one of them (both orders). Asserts `NaN` on the other row. Reproduces the silent broadcast without the fix.
- `PandasConverterTests.FlattensSingleSymbolBaseDataCollectionOfDynamicDataWithHeterogeneousProperties`: same shape through a flattened single-symbol collection. Reproduces the `ValueError` without the fix.
- End-to-end `QuantBook.UniverseHistory(universe, start, end, flatten=True)` over a `PythonData` universe with 504 heterogeneous constituents per day: reproduces the exact reported error without the fix, returns the expected flattened frame with it.
- Regression suites (`PandasConverter*`, `QuantBook*`, `PythonData`, `AlgorithmHistoryTests`, `AlgorithmChainsTests`): 1708 passed, 0 failed.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
