### PR TITLE
Report an OAuth authentication failure as a disconnection

### DIFF
--- a/Brokerages/Authentication/LeanOAuthTokenHandler.cs
+++ b/Brokerages/Authentication/LeanOAuthTokenHandler.cs
@@ -15,7 +15,9 @@
 
 using System;
 using QuantConnect.Api;
+using QuantConnect.Util;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace QuantConnect.Brokerages.Authentication
 {
@@ -50,12 +52,17 @@ namespace QuantConnect.Brokerages.Authentication
         /// <summary>
         /// The maximum number of retry attempts when fetching an access token.
         /// </summary>
-        protected virtual int MaxRetryCount { get; set; } = 3;
+        protected virtual int MaxRetryCount { get; set; } = 5;
 
         /// <summary>
         /// The time interval to wait between retry attempts when fetching an access token.
         /// </summary>
-        protected virtual TimeSpan RetryInterval { get; set; } = TimeSpan.FromSeconds(5);
+        protected virtual TimeSpan RetryInterval { get; set; } = TimeSpan.FromSeconds(15);
+
+        /// <summary>
+        /// The time interval between attempts to recover a failed authentication.
+        /// </summary>
+        protected virtual TimeSpan RecoveryInterval { get; set; } = TimeSpan.FromSeconds(30);
 
         /// <summary>
         /// Lock object used to synchronize token refresh across threads.
@@ -91,9 +98,25 @@ namespace QuantConnect.Brokerages.Authentication
         private DateTime _tokenExpiresAt;
 
         /// <summary>
+        /// Whether the last authentication failed, while true the recovery task owns the retrying.
+        /// Always accessed inside <see cref="_lock"/>.
+        /// </summary>
+        private bool _authenticationFailed;
+
+        /// <summary>
+        /// Cancels the recovery task, not null while one is running. Always accessed inside <see cref="_lock"/>.
+        /// </summary>
+        private CancellationTokenSource _recoveryCancellation;
+
+        /// <summary>
         /// Some padding before expiration to request a new token
         /// </summary>
         public TimeSpan OffsetBeforeExpiration { get; set; } = TimeSpan.FromMinutes(2);
+
+        /// <summary>
+        /// Raised when authentication succeeds
+        /// </summary>
+        public event EventHandler AuthenticationSucceeded;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LeanOAuthTokenHandler"/> class.
@@ -127,24 +150,17 @@ namespace QuantConnect.Brokerages.Authentication
                     return _tokenCredentials;
                 }
 
+                if (_authenticationFailed)
+                {
+                    // the recovery task is already retrying, fail fast instead of holding the lock for a token we know we can't get
+                    throw new InvalidOperationException($"LeanOAuthTokenHandler.{nameof(GetAccessToken)}: Authentication failed, waiting for it to recover.");
+                }
+
                 for (var retryCount = 0; retryCount <= MaxRetryCount; retryCount++)
                 {
                     try
                     {
-                        using var request = ApiUtils.CreateJsonPostRequest("live/auth0/refresh", _jsonBodyRequest);
-
-                        if (_apiClient.TryRequest<T>(request, out var response))
-                        {
-                            if (response.Success)
-                            {
-                                _tokenExpiresAt = DateTime.UtcNow + _tokenLifetime - OffsetBeforeExpiration;
-                                return _tokenCredentials = response;
-                            }
-                        }
-
-                        Logging.Log.Error($"LeanOAuthTokenHandler.{nameof(GetAccessToken)}: Failed to retrieve access token. Response: {response}. Last known expiry: {_tokenExpiresAt.ToStringInvariant()}.");
-                        throw new InvalidOperationException($"Authentication failed. " +
-                            $"Details: {(response?.Errors?.Count > 0 ? string.Join(",", response.Errors) : "empty")}");
+                        return RequestAccessToken();
                     }
                     catch when (retryCount < MaxRetryCount)
                     {
@@ -157,6 +173,8 @@ namespace QuantConnect.Brokerages.Authentication
                     }
                     catch (Exception ex)
                     {
+                        _authenticationFailed = true;
+                        StartRecovery();
                         OnAuthenticationFailed(ex);
                         throw;
                     }
@@ -165,6 +183,113 @@ namespace QuantConnect.Brokerages.Authentication
                 // Unreachable — the loop always returns or throws
                 throw new InvalidOperationException($"LeanOAuthTokenHandler.{nameof(GetAccessToken)}: Unexpected state in token retry loop.");
             }
+        }
+
+        /// <summary>
+        /// Stops the recovery task, if any, before releasing the handler.
+        /// </summary>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                lock (_lock)
+                {
+                    StopRecovery();
+                }
+            }
+
+            base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Requests a new access token, caching it and reporting the recovery of a failed authentication.
+        /// Always called inside <see cref="_lock"/>.
+        /// </summary>
+        /// <param name="logFailure">Whether to log a failed request, false for the recovery task so that a long
+        /// outage does not fill the log with one error every <see cref="RecoveryInterval"/>.</param>
+        /// <returns>A <see cref="LeanTokenCredentials"/> instance containing the token type and access token string.</returns>
+        private T RequestAccessToken(bool logFailure = true)
+        {
+            using var request = ApiUtils.CreateJsonPostRequest("live/auth0/refresh", _jsonBodyRequest);
+
+            if (_apiClient.TryRequest<T>(request, out var response) && response.Success)
+            {
+                _tokenExpiresAt = DateTime.UtcNow + _tokenLifetime - OffsetBeforeExpiration;
+                _tokenCredentials = response;
+
+                if (_authenticationFailed)
+                {
+                    _authenticationFailed = false;
+                    StopRecovery();
+                    AuthenticationSucceeded?.Invoke(this, EventArgs.Empty);
+                }
+
+                return response;
+            }
+
+            if (logFailure)
+            {
+                Logging.Log.Error($"LeanOAuthTokenHandler.{nameof(GetAccessToken)}: Failed to retrieve access token. Response: {response}. Last known expiry: {_tokenExpiresAt.ToStringInvariant()}.");
+            }
+            throw new InvalidOperationException($"Authentication failed. " +
+                $"Details: {(response?.Errors?.Count > 0 ? string.Join(",", response.Errors) : "empty")}");
+        }
+
+        /// <summary>
+        /// Starts the task that retries a failed authentication until it succeeds, so that recovering does not
+        /// depend on the brokerage happening to request another token. Always called inside <see cref="_lock"/>.
+        /// </summary>
+        private void StartRecovery()
+        {
+            if (_recoveryCancellation != null)
+            {
+                return;
+            }
+
+            var recoveryCancellation = _recoveryCancellation = new CancellationTokenSource();
+
+            Task.Factory.StartNew(() =>
+            {
+                try
+                {
+                    // the task owns the disposal of its cancellation source, so it can never wait on a disposed handle
+                    while (!recoveryCancellation.Token.WaitHandle.WaitOne(RecoveryInterval))
+                    {
+                        lock (_lock)
+                        {
+                            if (!_authenticationFailed)
+                            {
+                                break;
+                            }
+
+                            try
+                            {
+                                RequestAccessToken(logFailure: false);
+                                break;
+                            }
+                            catch (Exception ex)
+                            {
+                                Logging.Log.Debug($"LeanOAuthTokenHandler.{nameof(StartRecovery)}: {ex.Message}");
+                            }
+                        }
+                    }
+                }
+                finally
+                {
+                    recoveryCancellation.DisposeSafely();
+                }
+            }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+        }
+
+        /// <summary>
+        /// Stops the recovery task, which disposes of its own cancellation source once it exits.
+        /// Always called inside <see cref="_lock"/>.
+        /// </summary>
+        private void StopRecovery()
+        {
+            var recoveryCancellation = _recoveryCancellation;
+            _recoveryCancellation = null;
+            recoveryCancellation?.Cancel();
         }
     }
 }

--- a/Brokerages/Brokerage.cs
+++ b/Brokerages/Brokerage.cs
@@ -45,6 +45,11 @@ namespace QuantConnect.Brokerages
         private bool _syncedLiveBrokerageCashToday = true;
         private long _lastSyncTimeTicks = DateTime.UtcNow.Ticks;
 
+        private const int Connected = 1;
+        private const int Disconnected = 0;
+        // written by brokerage threads and read by the transaction handler, always through Interlocked/Volatile
+        private int _connectionState = Connected;
+
         /// <summary>
         /// Event that fires each time the brokerage order id changes
         /// </summary>
@@ -311,6 +316,22 @@ namespace QuantConnect.Brokerages
         {
             try
             {
+                // only let through actual state changes, else a retrying brokerage restarts Lean's recovery window on each attempt
+                if (e.Type == BrokerageMessageType.Disconnect)
+                {
+                    if (Interlocked.Exchange(ref _connectionState, Disconnected) == Disconnected)
+                    {
+                        return;
+                    }
+                }
+                else if (e.Type == BrokerageMessageType.Reconnect)
+                {
+                    if (Interlocked.Exchange(ref _connectionState, Connected) == Connected)
+                    {
+                        return;
+                    }
+                }
+
                 if (e.Type == BrokerageMessageType.Error)
                 {
                     Log.Error("Brokerage.OnMessage(): " + e);
@@ -329,8 +350,8 @@ namespace QuantConnect.Brokerages
         }
 
         /// <summary>
-        /// Creates a <see cref="LeanOAuthTokenHandler"/> and automatically wires it so that
-        /// authentication failures trigger a brokerage error message, causing Lean to shut down gracefully.
+        /// Creates a <see cref="LeanOAuthTokenHandler"/> and automatically wires it so that authentication failures
+        /// report the brokerage as disconnected, and the next successful authentication as reconnected.
         /// </summary>
         /// <param name="apiClient">The API client used to communicate with the Lean platform.</param>
         /// <param name="request">The request model used to generate the access token.</param>
@@ -343,8 +364,26 @@ namespace QuantConnect.Brokerages
             where T : LeanTokenCredentials
         {
             var handler = new LeanOAuthTokenHandler<T>(apiClient, request, tokenLifetime);
-            handler.AuthenticationFailed += (_, ex) => OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, "OAuthenticationFailed", ex.Message));
+            handler.AuthenticationFailed += (_, ex) => OnAuthenticationFailed(ex);
+            handler.AuthenticationSucceeded += (_, _) => OnAuthenticationSucceeded();
             return handler;
+        }
+
+        /// <summary>
+        /// Notifies that authentication has succeeded.
+        /// </summary>
+        protected virtual void OnAuthenticationSucceeded()
+        {
+            OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Reconnect, "OAuthenticationSucceeded", "Authentication succeeded."));
+        }
+
+        /// <summary>
+        /// Notifies that authentication has failed.
+        /// </summary>
+        /// <param name="exception">The exception that caused the authentication failure.</param>
+        protected virtual void OnAuthenticationFailed(Exception exception)
+        {
+            OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Disconnect, "OAuthenticationFailed", exception.Message));
         }
 
         /// <summary>
@@ -486,7 +525,8 @@ namespace QuantConnect.Brokerages
                 _syncedLiveBrokerageCashToday = false;
             }
 
-            return !_syncedLiveBrokerageCashToday && currentTimeNewYork.TimeOfDay >= LiveBrokerageCashSyncTime;
+            return !_syncedLiveBrokerageCashToday && currentTimeNewYork.TimeOfDay >= LiveBrokerageCashSyncTime
+                && Volatile.Read(ref _connectionState) == Connected;
         }
 
         /// <summary>

--- a/Brokerages/WebSocketClientWrapper.cs
+++ b/Brokerages/WebSocketClientWrapper.cs
@@ -215,13 +215,12 @@ namespace QuantConnect.Brokerages
         {
             var receiveBuffer = new byte[ReceiveBufferSize];
 
+            const int maximumWaitTimeOnError = 120 * 1000;
+            const int minimumWaitTimeOnError = 2 * 1000;
+            var waitTimeOnError = minimumWaitTimeOnError;
             while (_cts is { IsCancellationRequested: false })
             {
                 Log.Trace($"WebSocketClientWrapper.HandleConnection({_url}): Connecting...");
-
-                const int maximumWaitTimeOnError = 120 * 1000;
-                const int minimumWaitTimeOnError = 2 * 1000;
-                var waitTimeOnError = minimumWaitTimeOnError;
                 using (var connectionCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token))
                 {
                     try
@@ -241,21 +240,20 @@ namespace QuantConnect.Brokerages
                         while ((_client.State == WebSocketState.Open || _client.State == WebSocketState.CloseSent) &&
                             !connectionCts.IsCancellationRequested)
                         {
+                            // reset wait time
+                            waitTimeOnError = minimumWaitTimeOnError;
                             var messageData = ReceiveMessage(_client, connectionCts.Token, receiveBuffer);
 
                             if (messageData == null)
                             {
                                 break;
                             }
-
-                            // reset wait time
-                            waitTimeOnError = minimumWaitTimeOnError;
                             OnMessage(new WebSocketMessage(this, messageData));
                         }
                     }
                     catch (OperationCanceledException) { }
                     catch (ObjectDisposedException) { }
-                    catch (WebSocketException ex)
+                    catch (Exception ex)
                     {
                         if (!connectionCts.IsCancellationRequested)
                         {
@@ -263,14 +261,7 @@ namespace QuantConnect.Brokerages
                             connectionCts.Token.WaitHandle.WaitOne(waitTimeOnError);
 
                             // increase wait time until a maximum value. This is useful during brokerage down times
-                            waitTimeOnError += Math.Min(maximumWaitTimeOnError, waitTimeOnError);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        if (!connectionCts.IsCancellationRequested)
-                        {
-                            OnError(new WebSocketError(ex.Message, ex));
+                            waitTimeOnError = Math.Min(maximumWaitTimeOnError, waitTimeOnError * 2);
                         }
                     }
 

--- a/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
+++ b/Engine/TransactionHandlers/BrokerageTransactionHandler.cs
@@ -755,6 +755,10 @@ namespace QuantConnect.Lean.Engine.TransactionHandlers
                             throw new Exception("The maximum number of attempts for brokerage cash sync has been reached.");
                         }
                     }
+                    else
+                    {
+                        _failedCashSyncAttempts = 0;
+                    }
                 }
             }
 


### PR DESCRIPTION
Closes QuantConnect/Lean.Brokerages.CharlesSchwab#106
Closes QuantConnect/Lean.Brokerages.Tastytrade#32

## Problem

An OAuth session that fails to refresh stops the live algorithm instead of disconnecting it: `Brokerage.CreateOAuthTokenHandler` wires `AuthenticationFailed` to a `BrokerageMessageType.Error`, and `DefaultBrokerageMessageHandler` turns that into `SetRuntimeError`. Its two callers have both hit it — a Schwab session expiring on a Saturday, 12 days of state lost when re-authorizing on the website would have been enough (CharlesSchwab#106), and `live/auth0/refresh` failing for 14 minutes, 36 error rows across 17 users on a routine refresh (Tastytrade#32).

Lean already has the policy these need: a `Disconnect` keeps the run alive for 15 minutes while an exchange is open, or until shortly before the next open while all are closed, and a `Reconnect` cancels the shutdown.

Keeping the run alive is also the only available fix. A redeploy cannot survive a token outage: setup fetches open orders, holdings and the cash balance, and each failure is fatal (`BrokerageSetupHandler.cs:375,405,420`). Both brokerages die even earlier, fetching session state from a websocket wrapper constructor, but moving that only shifts the failure a few lines. So the algorithm has to not stop, and recover in place. Tastytrade#32's second defect is filed as blocking the redeploy; it does not.

## Changes

- **An authentication failure is a disconnection.** `CreateOAuthTokenHandler` reports `AuthenticationFailed` as a `Disconnect` and the next successfully fetched token as a `Reconnect`, through overridable methods.

- **Only actual state changes are emitted.** `Brokerage.OnMessage` drops a `Disconnect` while already disconnected and a `Reconnect` while already connected. Otherwise a brokerage retrying a failed connection emits one disconnection per attempt, each restarting the recovery window, and a routine token refresh emits a `Reconnect` that cancels a shutdown armed by an unrelated disconnection. Written from brokerage threads and read from the transaction handler thread, so the transition goes through `Interlocked.Exchange`.

- **The token handler owns its recovery.** Nothing retried a failed authentication, so recovering depended on the brokerage happening to request another token — which, for one whose stream is healthy and whose REST refresh is the only thing failing, may not happen for a day. A failure now starts a task that retries every `RecoveryInterval` until it succeeds, and callers fail fast meanwhile instead of each running the retry loop under the token lock.

- **The websocket backoff is applied and kept.** `WebSocketClientWrapper.HandleConnection` waited only for a `WebSocketException`; anything thrown from `OnOpen`, which is where both brokerages authenticate, reconnected with no delay at all. Hoisting the wait out of the connection loop also fixed two defects in it: every reconnect reset it, so the 2s → 120s escalation never escalated, and the maximum was applied to the increment instead of to the total.

- **Cash sync** is skipped while the brokerage is disconnected, and `_failedCashSyncAttempts` is reset on a successful sync — the 5 attempts were counted over the whole deployment.

`LeanOAuthTokenHandler.cs` reads better with whitespace hidden: the request moved into `RequestAccessToken`, shared by the retry loop and the recovery task. InteractiveBrokers' FIX WebApi builds the handler directly and never subscribes to `AuthenticationFailed`, so it is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtWz94RVkwpvgjoswaRxGa
