### PR TITLE
Fix stop-limit fills after trigger bar

### DIFF
--- a/Common/Messages/Messages.Orders.Fills.cs
+++ b/Common/Messages/Messages.Orders.Fills.cs
@@ -57,6 +57,14 @@ namespace QuantConnect
             }
 
             /// <summary>
+            /// Returns a string message saying that the order was filled using the open price due to a favorable gap
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static string FilledWithOpenDueToFavorableGap(Securities.Security security, Prices prices)
+            {
+                return Invariant($@"Due to a favorable gap at {prices.EndTime.ToStringInvariant()} {security.Exchange.TimeZone}, order filled using the open price ({prices.Open})");
+            }
+            /// <summary>
             /// Returns a string message containing the given subscribedTypes
             /// </summary>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Common/Orders/Fills/EquityFillModel.cs
+++ b/Common/Orders/Fills/EquityFillModel.cs
@@ -304,25 +304,41 @@ namespace QuantConnect.Orders.Fills
             if (pricesEndTime <= order.Time) return fill;
 
             //Check if the Stop Order was filled: opposite to a limit order
+            var triggeredOnEarlierBar = order.StopTriggered;
             switch (order.Direction)
             {
                 case OrderDirection.Buy:
                     //-> 1.2 Buy Stop: If Price Above Setpoint, Buy:
-                    if (prices.High > order.StopPrice || order.StopTriggered)
+                    if (prices.High > order.StopPrice || triggeredOnEarlierBar)
                     {
-                        if (!order.StopTriggered)
+                        if (!triggeredOnEarlierBar)
                         {
                             order.StopTriggered = true;
                             Parameters.OnOrderUpdated(order);
                         }
 
-                        // Fill the limit order, using closing price of bar:
-                        // Note > Can't use minimum price, because no way to be sure minimum wasn't before the stop triggered.
-                        if (prices.Current < order.LimitPrice)
+                        if (triggeredOnEarlierBar)
                         {
+                            // The entire bar is post-trigger, so the limit leg behaves as a resting limit order.
+                            var tradeBar = GetBestEffortTradeBar(asset, order.Time);
+                            if (tradeBar != null && tradeBar.Low < order.LimitPrice)
+                            {
+                                fill.Status = OrderStatus.Filled;
+                                fill.FillPrice = order.LimitPrice;
+                                fill.FillQuantity = order.Quantity;
+
+                                if (tradeBar.Open < order.LimitPrice)
+                                {
+                                    fill.FillPrice = tradeBar.Open;
+                                    fill.Message = Messages.EquityFillModel.FilledWithOpenDueToFavorableGap(asset, tradeBar);
+                                }
+                            }
+                        }
+                        else if (prices.Current < order.LimitPrice)
+                        {
+                            // On the trigger bar, preserve the conservative close-based test.
                             fill.Status = OrderStatus.Filled;
                             fill.FillPrice = Math.Min(prices.High, order.LimitPrice);
-                            // assume the order completely filled
                             fill.FillQuantity = order.Quantity;
                         }
                     }
@@ -330,27 +346,41 @@ namespace QuantConnect.Orders.Fills
 
                 case OrderDirection.Sell:
                     //-> 1.1 Sell Stop: If Price below setpoint, Sell:
-                    if (prices.Low < order.StopPrice || order.StopTriggered)
+                    if (prices.Low < order.StopPrice || triggeredOnEarlierBar)
                     {
-                        if (!order.StopTriggered)
+                        if (!triggeredOnEarlierBar)
                         {
                             order.StopTriggered = true;
                             Parameters.OnOrderUpdated(order);
                         }
 
-                        // Fill the limit order, using minimum price of the bar
-                        // Note > Can't use minimum price, because no way to be sure minimum wasn't before the stop triggered.
-                        if (prices.Current > order.LimitPrice)
+                        if (triggeredOnEarlierBar)
                         {
+                            // The entire bar is post-trigger, so the limit leg behaves as a resting limit order.
+                            var tradeBar = GetBestEffortTradeBar(asset, order.Time);
+                            if (tradeBar != null && tradeBar.High > order.LimitPrice)
+                            {
+                                fill.Status = OrderStatus.Filled;
+                                fill.FillPrice = order.LimitPrice;
+                                fill.FillQuantity = order.Quantity;
+
+                                if (tradeBar.Open > order.LimitPrice)
+                                {
+                                    fill.FillPrice = tradeBar.Open;
+                                    fill.Message = Messages.EquityFillModel.FilledWithOpenDueToFavorableGap(asset, tradeBar);
+                                }
+                            }
+                        }
+                        else if (prices.Current > order.LimitPrice)
+                        {
+                            // On the trigger bar, preserve the conservative close-based test.
                             fill.Status = OrderStatus.Filled;
                             fill.FillPrice = Math.Max(prices.Low, order.LimitPrice);
-                            // assume the order completely filled
                             fill.FillQuantity = order.Quantity;
                         }
                     }
                     break;
             }
-
             return fill;
         }
 

--- a/Common/Orders/Fills/FillModel.cs
+++ b/Common/Orders/Fills/FillModel.cs
@@ -506,25 +506,40 @@ namespace QuantConnect.Orders.Fills
             if (pricesEndTime <= order.Time) return fill;
 
             //Check if the Stop Order was filled: opposite to a limit order
+            var triggeredOnEarlierBar = order.StopTriggered;
             switch (order.Direction)
             {
                 case OrderDirection.Buy:
                     //-> 1.2 Buy Stop: If Price Above Setpoint, Buy:
-                    if (prices.High > order.StopPrice || order.StopTriggered)
+                    if (prices.High > order.StopPrice || triggeredOnEarlierBar)
                     {
-                        if (!order.StopTriggered)
+                        if (!triggeredOnEarlierBar)
                         {
                             order.StopTriggered = true;
                             Parameters.OnOrderUpdated(order);
                         }
 
-                        // Fill the limit order, using closing price of bar:
-                        // Note > Can't use minimum price, because no way to be sure minimum wasn't before the stop triggered.
-                        if (prices.Current < order.LimitPrice)
+                        if (triggeredOnEarlierBar)
                         {
+                            // The entire bar is post-trigger, so the limit leg behaves as a resting limit order.
+                            if (prices.Low < order.LimitPrice)
+                            {
+                                fill.Status = OrderStatus.Filled;
+                                fill.FillPrice = order.LimitPrice;
+                                fill.FillQuantity = order.Quantity;
+
+                                if (prices.Open < order.LimitPrice)
+                                {
+                                    fill.FillPrice = prices.Open;
+                                    fill.Message = Messages.FillModel.FilledWithOpenDueToFavorableGap(asset, prices);
+                                }
+                            }
+                        }
+                        else if (prices.Current < order.LimitPrice)
+                        {
+                            // On the trigger bar, preserve the conservative close-based test.
                             fill.Status = OrderStatus.Filled;
                             fill.FillPrice = Math.Min(prices.High, order.LimitPrice);
-                            // assume the order completely filled
                             fill.FillQuantity = order.Quantity;
                         }
                     }
@@ -532,27 +547,40 @@ namespace QuantConnect.Orders.Fills
 
                 case OrderDirection.Sell:
                     //-> 1.1 Sell Stop: If Price below setpoint, Sell:
-                    if (prices.Low < order.StopPrice || order.StopTriggered)
+                    if (prices.Low < order.StopPrice || triggeredOnEarlierBar)
                     {
-                        if (!order.StopTriggered)
+                        if (!triggeredOnEarlierBar)
                         {
                             order.StopTriggered = true;
                             Parameters.OnOrderUpdated(order);
                         }
 
-                        // Fill the limit order, using minimum price of the bar
-                        // Note > Can't use minimum price, because no way to be sure minimum wasn't before the stop triggered.
-                        if (prices.Current > order.LimitPrice)
+                        if (triggeredOnEarlierBar)
                         {
+                            // The entire bar is post-trigger, so the limit leg behaves as a resting limit order.
+                            if (prices.High > order.LimitPrice)
+                            {
+                                fill.Status = OrderStatus.Filled;
+                                fill.FillPrice = order.LimitPrice;
+                                fill.FillQuantity = order.Quantity;
+
+                                if (prices.Open > order.LimitPrice)
+                                {
+                                    fill.FillPrice = prices.Open;
+                                    fill.Message = Messages.FillModel.FilledWithOpenDueToFavorableGap(asset, prices);
+                                }
+                            }
+                        }
+                        else if (prices.Current > order.LimitPrice)
+                        {
+                            // On the trigger bar, preserve the conservative close-based test.
                             fill.Status = OrderStatus.Filled;
                             fill.FillPrice = Math.Max(prices.Low, order.LimitPrice);
-                            // assume the order completely filled
                             fill.FillQuantity = order.Quantity;
                         }
                     }
                     break;
             }
-
             return fill;
         }
 

--- a/Tests/Common/Orders/Fills/EquityFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/EquityFillModelTests.cs
@@ -133,6 +133,161 @@ namespace QuantConnect.Tests.Common.Orders.Fills
         }
 
         [Test]
+        public void StopLimitBuyFillsOnLimitPenetrationAfterEarlierTrigger()
+        {
+            var model = new EquityFillModel();
+            var order = new StopLimitOrder(Symbols.SPY, 100, 100m, 100.25m, Noon);
+            var config = CreateTradeBarConfig(Symbols.SPY);
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(Currencies.USD, 0, 1m),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache()
+            );
+
+            security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+
+            // Trigger bar: stop crossed, but close remains above the buy limit.
+            security.SetMarketPrice(new TradeBar(
+                Noon, Symbols.SPY, 100.50m, 101.50m, 100.40m, 101.00m, 100));
+
+            var fill = model.Fill(new FillModelParameters(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour,
+                null)).Single();
+
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+            Assert.IsTrue(order.StopTriggered);
+
+            // Later bar: the resting limit is penetrated although the close remains above it.
+            security.SetMarketPrice(new TradeBar(
+                Noon.AddMinutes(1), Symbols.SPY, 100.60m, 100.80m, 99.80m, 100.60m, 100));
+
+            fill = model.Fill(new FillModelParameters(
+                security,
+                order,
+                new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour,
+                null)).Single();
+
+            Assert.AreEqual(OrderStatus.Filled, fill.Status);
+            Assert.AreEqual(order.LimitPrice, fill.FillPrice);
+            Assert.AreEqual(order.Quantity, fill.FillQuantity);
+        }
+        [Test]
+        public void StopLimitBuyFillsAtOpenAfterEarlierTrigger()
+        {
+            var model = new EquityFillModel();
+            var order = new StopLimitOrder(Symbols.SPY, 100, 100m, 100.25m, Noon);
+            var config = CreateTradeBarConfig(Symbols.SPY);
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(Currencies.USD, 0, 1m),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache()
+            );
+            security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+
+            security.SetMarketPrice(new TradeBar(
+                Noon, Symbols.SPY, 100.50m, 101.50m, 100.40m, 101.00m, 100));
+
+            var fill = model.Fill(new FillModelParameters(
+                security, order, new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour, null)).Single();
+
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+            Assert.IsTrue(order.StopTriggered);
+
+            security.SetMarketPrice(new TradeBar(
+                Noon.AddMinutes(1), Symbols.SPY, 99.80m, 100.80m, 99.50m, 100.60m, 100));
+
+            fill = model.Fill(new FillModelParameters(
+                security, order, new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour, null)).Single();
+
+            Assert.AreEqual(OrderStatus.Filled, fill.Status);
+            Assert.AreEqual(99.80m, fill.FillPrice);
+            Assert.IsTrue(fill.Message.Contains("favorable gap", StringComparison.InvariantCultureIgnoreCase));
+        }
+
+        [Test]
+        public void StopLimitBuyDoesNotUseLowOnTriggerBar()
+        {
+            var model = new EquityFillModel();
+            var order = new StopLimitOrder(Symbols.SPY, 100, 100m, 100.25m, Noon);
+            var config = CreateTradeBarConfig(Symbols.SPY);
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(Currencies.USD, 0, 1m),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache()
+            );
+            security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+
+            // The bar crosses both stop and limit, but closes above the limit.
+            // We cannot know whether the low occurred before the stop trigger.
+            security.SetMarketPrice(new TradeBar(
+                Noon, Symbols.SPY, 100.50m, 101.50m, 99.80m, 101.00m, 100));
+
+            var fill = model.Fill(new FillModelParameters(
+                security, order, new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour, null)).Single();
+
+            Assert.IsTrue(order.StopTriggered);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+            Assert.AreEqual(0, fill.FillQuantity);
+        }
+
+        [Test]
+        public void StopLimitSellFillsOnLimitPenetrationAfterEarlierTrigger()
+        {
+            var model = new EquityFillModel();
+            var order = new StopLimitOrder(Symbols.SPY, -100, 100m, 99.75m, Noon);
+            var config = CreateTradeBarConfig(Symbols.SPY);
+            var security = new Security(
+                SecurityExchangeHoursTests.CreateUsEquitySecurityExchangeHours(),
+                config,
+                new Cash(Currencies.USD, 0, 1m),
+                SymbolProperties.GetDefault(Currencies.USD),
+                ErrorCurrencyConverter.Instance,
+                RegisteredSecurityDataTypesProvider.Null,
+                new SecurityCache()
+            );
+            security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+
+            security.SetMarketPrice(new TradeBar(
+                Noon, Symbols.SPY, 100.20m, 100.30m, 98.50m, 99.50m, 100));
+
+            var fill = model.Fill(new FillModelParameters(
+                security, order, new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour, null)).Single();
+
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+            Assert.IsTrue(order.StopTriggered);
+
+            security.SetMarketPrice(new TradeBar(
+                Noon.AddMinutes(1), Symbols.SPY, 99.60m, 100.10m, 99.40m, 99.60m, 100));
+
+            fill = model.Fill(new FillModelParameters(
+                security, order, new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour, null)).Single();
+
+            Assert.AreEqual(OrderStatus.Filled, fill.Status);
+            Assert.AreEqual(order.LimitPrice, fill.FillPrice);
+            Assert.AreEqual(order.Quantity, fill.FillQuantity);
+        }
+        [Test]
         public void PerformsStopLimitFillBuy()
         {
             var model = new EquityFillModel();
@@ -174,13 +329,14 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             Assert.AreEqual(0, fill.FillPrice);
             Assert.AreEqual(OrderStatus.None, fill.Status);
 
-            security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101.66m));
+            security.SetMarketPrice(new TradeBar(
+                Noon, Symbols.SPY, 102m, 102m, 101.66m, 101.66m, 100));
 
             fill = model.StopLimitFill(security, order);
 
             // this fills worst case scenario, so it's at the limit price
             Assert.AreEqual(order.Quantity, fill.FillQuantity);
-            Assert.AreEqual(security.High, fill.FillPrice);
+            Assert.AreEqual(order.LimitPrice, fill.FillPrice);
             Assert.AreEqual(OrderStatus.Filled, fill.Status);
         }
 
@@ -226,13 +382,14 @@ namespace QuantConnect.Tests.Common.Orders.Fills
             Assert.AreEqual(0, fill.FillPrice);
             Assert.AreEqual(OrderStatus.None, fill.Status);
 
-            security.SetMarketPrice(new IndicatorDataPoint(Symbols.SPY, Noon, 101.66m));
+            security.SetMarketPrice(new TradeBar(
+                Noon, Symbols.SPY, 101m, 101.66m, 101m, 101.66m, 100));
 
             fill = model.StopLimitFill(security, order);
 
             // this fills worst case scenario, so it's at the limit price
             Assert.AreEqual(order.Quantity, fill.FillQuantity);
-            Assert.AreEqual(security.Low, fill.FillPrice);
+            Assert.AreEqual(order.LimitPrice, fill.FillPrice);
             Assert.AreEqual(OrderStatus.Filled, fill.Status);
         }
 

--- a/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
+++ b/Tests/Common/Orders/Fills/ImmediateFillModelTests.cs
@@ -229,6 +229,123 @@ namespace QuantConnect.Tests.Common.Orders.Fills
 
         [TestCase(true)]
         [TestCase(false)]
+        public void StopLimitBuyFillsOnLimitPenetrationAfterEarlierTrigger(bool isInternal)
+        {
+            var model = new ImmediateFillModel();
+            var order = new StopLimitOrder(Symbols.SPY, 100, 100m, 100.25m, Noon);
+            var config = CreateTradeBarConfig(Symbols.SPY, isInternal);
+            var security = GetSecurity(config);
+            security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+
+            security.SetMarketPrice(new TradeBar(
+                Noon, Symbols.SPY, 100.50m, 101.50m, 100.40m, 101.00m, 100));
+
+            var fill = model.Fill(new FillModelParameters(
+                security, order, new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour, null)).Single();
+
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+            Assert.IsTrue(order.StopTriggered);
+
+            security.SetMarketPrice(new TradeBar(
+                Noon.AddMinutes(1), Symbols.SPY, 100.60m, 100.80m, 99.80m, 100.60m, 100));
+
+            fill = model.Fill(new FillModelParameters(
+                security, order, new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour, null)).Single();
+
+            Assert.AreEqual(OrderStatus.Filled, fill.Status);
+            Assert.AreEqual(order.LimitPrice, fill.FillPrice);
+            Assert.AreEqual(order.Quantity, fill.FillQuantity);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void StopLimitBuyFillsAtOpenAfterEarlierTrigger(bool isInternal)
+        {
+            var model = new ImmediateFillModel();
+            var order = new StopLimitOrder(Symbols.SPY, 100, 100m, 100.25m, Noon);
+            var config = CreateTradeBarConfig(Symbols.SPY, isInternal);
+            var security = GetSecurity(config);
+            security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+
+            security.SetMarketPrice(new TradeBar(
+                Noon, Symbols.SPY, 100.50m, 101.50m, 100.40m, 101.00m, 100));
+
+            var fill = model.Fill(new FillModelParameters(
+                security, order, new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour, null)).Single();
+
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+            Assert.IsTrue(order.StopTriggered);
+
+            security.SetMarketPrice(new TradeBar(
+                Noon.AddMinutes(1), Symbols.SPY, 99.80m, 100.80m, 99.50m, 100.60m, 100));
+
+            fill = model.Fill(new FillModelParameters(
+                security, order, new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour, null)).Single();
+
+            Assert.AreEqual(OrderStatus.Filled, fill.Status);
+            Assert.AreEqual(99.80m, fill.FillPrice);
+            Assert.IsTrue(fill.Message.Contains("favorable gap", StringComparison.InvariantCultureIgnoreCase));
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void StopLimitBuyDoesNotUseLowOnTriggerBar(bool isInternal)
+        {
+            var model = new ImmediateFillModel();
+            var order = new StopLimitOrder(Symbols.SPY, 100, 100m, 100.25m, Noon);
+            var config = CreateTradeBarConfig(Symbols.SPY, isInternal);
+            var security = GetSecurity(config);
+            security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+
+            security.SetMarketPrice(new TradeBar(
+                Noon, Symbols.SPY, 100.50m, 101.50m, 99.80m, 101.00m, 100));
+
+            var fill = model.Fill(new FillModelParameters(
+                security, order, new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour, null)).Single();
+
+            Assert.IsTrue(order.StopTriggered);
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+            Assert.AreEqual(0, fill.FillQuantity);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void StopLimitSellFillsOnLimitPenetrationAfterEarlierTrigger(bool isInternal)
+        {
+            var model = new ImmediateFillModel();
+            var order = new StopLimitOrder(Symbols.SPY, -100, 100m, 99.75m, Noon);
+            var config = CreateTradeBarConfig(Symbols.SPY, isInternal);
+            var security = GetSecurity(config);
+            security.SetLocalTimeKeeper(TimeKeeper.GetLocalTimeKeeper(TimeZones.NewYork));
+
+            security.SetMarketPrice(new TradeBar(
+                Noon, Symbols.SPY, 100.20m, 100.30m, 98.50m, 99.50m, 100));
+
+            var fill = model.Fill(new FillModelParameters(
+                security, order, new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour, null)).Single();
+
+            Assert.AreEqual(OrderStatus.None, fill.Status);
+            Assert.IsTrue(order.StopTriggered);
+
+            security.SetMarketPrice(new TradeBar(
+                Noon.AddMinutes(1), Symbols.SPY, 99.60m, 100.10m, 99.40m, 99.60m, 100));
+
+            fill = model.Fill(new FillModelParameters(
+                security, order, new MockSubscriptionDataConfigProvider(config),
+                Time.OneHour, null)).Single();
+
+            Assert.AreEqual(OrderStatus.Filled, fill.Status);
+            Assert.AreEqual(order.LimitPrice, fill.FillPrice);
+            Assert.AreEqual(order.Quantity, fill.FillQuantity);
+        }
+        [TestCase(true)]
+        [TestCase(false)]
         public void PerformsStopLimitFillBuy(bool isInternal)
         {
             var model = new ImmediateFillModel();


### PR DESCRIPTION
#### Description

Updates stop-limit fill handling so that bars after the stop has already triggered use resting limit-order semantics.

The trigger bar retains the existing conservative close-based check because OHLC data does not reveal whether the bar's high/low occurred before or after the stop trigger. On subsequent bars, the entire bar is post-trigger, so:

* Buy stop-limit orders fill when the bar low penetrates the limit price.
* Sell stop-limit orders fill when the bar high penetrates the limit price.
* Favorable gaps fill at the opening price.
* The existing trigger-bar behavior remains unchanged.

The change is applied to both `EquityFillModel.StopLimitFill` and the base `FillModel.StopLimitFill`.

#### Related Issue

Fixes #9773

#### Motivation and Context

After a stop-limit order triggered, LEAN continued to apply the close-based limit test on every subsequent bar.

This could leave an already-triggered stop-limit order unfilled even when a later bar traded through its limit price, as long as that bar did not also close through the limit.

The close-based rule is appropriate on the trigger bar because the ordering of OHLC values is unknown. It is unnecessarily conservative on later bars, where the entire price range necessarily occurred after the stop had already triggered.

This change distinguishes those two cases and applies the existing resting limit-order behavior to subsequent bars.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

Added regression coverage for both `EquityFillModel` and the base `FillModel`, including:

* Buy stop-limit filling on a later-bar limit penetration while the close remains above the limit.
* Buy stop-limit filling at the open on a favorable gap.
* Trigger-bar low penetration not causing a fill when the close remains above the limit.
* Sell-side mirror of the later-bar penetration case.

Local test results:

* Targeted stop-limit regression corridor: **24/24 passed**
* `EquityFillModelTests` and `ImmediateFillModelTests`: **236/236 passed**

#### Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Refactor (non-breaking change which improves implementation)
* [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Non-functional change (xml comments/[document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md)ation/etc)

#### Checklist:

* [x] My code follows the code style of this project.
* [ ] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
* [x] I have added tests to cover my changes.
* [x] All new and relevant existing tests passed.
* [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`