### PR TITLE
Use ThreeMonths as the AccessionNumber default period

### DIFF
--- a/Common/Data/Fundamental/Generated/EarningReportsAccessionNumber.cs
+++ b/Common/Data/Fundamental/Generated/EarningReportsAccessionNumber.cs
@@ -31,7 +31,7 @@ namespace QuantConnect.Data.Fundamental
         /// <summary>
         /// The default period
         /// </summary>
-        protected override string DefaultPeriod => "OneMonth";
+        protected override string DefaultPeriod => "ThreeMonths";
 
         /// <summary>
         /// Gets/sets the OneMonth period value for the field
@@ -66,7 +66,7 @@ namespace QuantConnect.Data.Fundamental
         /// <summary>
         /// Returns true if the field contains a value for the default period
         /// </summary>
-        public override bool HasValue => !BaseFundamentalDataProvider.IsNone(typeof(string), FundamentalService.Get<string>(TimeProvider.GetUtcNow(), SecurityIdentifier, FundamentalProperty.EarningReports_AccessionNumber_OneMonth));
+        public override bool HasValue => !BaseFundamentalDataProvider.IsNone(typeof(string), FundamentalService.Get<string>(TimeProvider.GetUtcNow(), SecurityIdentifier, FundamentalProperty.EarningReports_AccessionNumber_ThreeMonths));
 
         /// <summary>
         /// Returns the default value for the field
@@ -75,7 +75,7 @@ namespace QuantConnect.Data.Fundamental
         {
             get
             {
-                var defaultValue = FundamentalService.Get<string>(TimeProvider.GetUtcNow(), SecurityIdentifier, FundamentalProperty.EarningReports_AccessionNumber_OneMonth);
+                var defaultValue = FundamentalService.Get<string>(TimeProvider.GetUtcNow(), SecurityIdentifier, FundamentalProperty.EarningReports_AccessionNumber_ThreeMonths);
                 if (!BaseFundamentalDataProvider.IsNone(typeof(string), defaultValue))
                 {
                     return defaultValue;

--- a/Common/Data/Fundamental/Generated/FinancialStatementsAccessionNumber.cs
+++ b/Common/Data/Fundamental/Generated/FinancialStatementsAccessionNumber.cs
@@ -31,7 +31,7 @@ namespace QuantConnect.Data.Fundamental
         /// <summary>
         /// The default period
         /// </summary>
-        protected override string DefaultPeriod => "OneMonth";
+        protected override string DefaultPeriod => "ThreeMonths";
 
         /// <summary>
         /// Gets/sets the OneMonth period value for the field
@@ -66,7 +66,7 @@ namespace QuantConnect.Data.Fundamental
         /// <summary>
         /// Returns true if the field contains a value for the default period
         /// </summary>
-        public override bool HasValue => !BaseFundamentalDataProvider.IsNone(typeof(string), FundamentalService.Get<string>(TimeProvider.GetUtcNow(), SecurityIdentifier, FundamentalProperty.FinancialStatements_AccessionNumber_OneMonth));
+        public override bool HasValue => !BaseFundamentalDataProvider.IsNone(typeof(string), FundamentalService.Get<string>(TimeProvider.GetUtcNow(), SecurityIdentifier, FundamentalProperty.FinancialStatements_AccessionNumber_ThreeMonths));
 
         /// <summary>
         /// Returns the default value for the field
@@ -75,7 +75,7 @@ namespace QuantConnect.Data.Fundamental
         {
             get
             {
-                var defaultValue = FundamentalService.Get<string>(TimeProvider.GetUtcNow(), SecurityIdentifier, FundamentalProperty.FinancialStatements_AccessionNumber_OneMonth);
+                var defaultValue = FundamentalService.Get<string>(TimeProvider.GetUtcNow(), SecurityIdentifier, FundamentalProperty.FinancialStatements_AccessionNumber_ThreeMonths);
                 if (!BaseFundamentalDataProvider.IsNone(typeof(string), defaultValue))
                 {
                     return defaultValue;

--- a/Tests/Common/Data/Fundamental/FundamentalTests.cs
+++ b/Tests/Common/Data/Fundamental/FundamentalTests.cs
@@ -40,6 +40,26 @@ namespace QuantConnect.Tests.Common.Data.Fundamental
         }
 
         [Test]
+        public void AccessionNumberDefaultsToThreeMonths()
+        {
+            var fine = new QuantConnect.Data.Fundamental.Fundamental(new DateTime(2014, 04, 01), Symbols.AAPL);
+
+            Assert.IsTrue(fine.EarningReports.AccessionNumber.HasValue);
+            Assert.AreEqual("0001193125-13-416534", fine.EarningReports.AccessionNumber.Value);
+            Assert.AreEqual("0001193125-13-416534", fine.EarningReports.AccessionNumber.GetPeriodValue(""));
+            Assert.IsTrue(fine.FinancialStatements.AccessionNumber.HasValue);
+        }
+
+        [Test]
+        public void AccessionNumberHasNoValueWhenItIsMissing()
+        {
+            var fine = new QuantConnect.Data.Fundamental.Fundamental(new DateTime(2014, 04, 01), Symbols.SPY);
+
+            Assert.IsFalse(fine.EarningReports.AccessionNumber.HasValue);
+            Assert.IsFalse(fine.FinancialStatements.AccessionNumber.HasValue);
+        }
+
+        [Test]
         public void ZeroMarketCapForDefaultObject()
         {
             var fine = new QuantConnect.Data.Fundamental.Fundamental();

--- a/Tests/Common/Data/Fundamental/TestFundamentalDataProvider.cs
+++ b/Tests/Common/Data/Fundamental/TestFundamentalDataProvider.cs
@@ -118,6 +118,14 @@ namespace QuantConnect.Tests.Common.Data.Fundamental
                         return industryTemplateCode;
                     }
                     return string.Empty;
+                case "EarningReports_AccessionNumber_ThreeMonths":
+                case "FinancialStatements_AccessionNumber_ThreeMonths":
+                    if (securityIdentifier.Symbol == "AAPL")
+                    {
+                        return "0001193125-13-416534";
+                    }
+                    // null and not string.Empty, an empty string would count as a real value
+                    return null;
                 case "EarningRatios_EquityPerShareGrowth_OneYear":
                     if(_equityPerShareGrowthOneYear.TryGetValue(securityIdentifier.ToString(), out var ePSG))
                     {


### PR DESCRIPTION
#### Description

Both `AccessionNumber` classes used `DefaultPeriod => "OneMonth"`. I changed them to `"ThreeMonths"` and made the `HasValue` and `Value` overrides read the 3M slot too. Same 3 line change in both files:

- `Common/Data/Fundamental/Generated/EarningReportsAccessionNumber.cs`
- `Common/Data/Fundamental/Generated/FinancialStatementsAccessionNumber.cs`

They now match the other filing metadata fields like `EarningReportsFileDate.cs`. The generator isn't in this repo, so I edited the generated files.

#### Related Issue

#9777

#### Motivation and Context

Morningstar never fills the 1M slot, so `HasValue` was false on every row while `Value` still found the number through the `MultiPeriodField.Value` fallback. The two disagreed on every populated row, and people who check `has_value` first think the accession number is missing.

`DefaultPeriod` is also used by `ConvertPeriod`, so `GetPeriodValue("")` read the wrong slot as well. I changed all three places together.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

Two new tests in `FundamentalTests.cs`, and I gave `TestFundamentalDataProvider` a 3M accession number for AAPL so there is something to read.

- `AccessionNumberDefaultsToThreeMonths`: `HasValue`, `Value` and `GetPeriodValue("")` all agree with the 3M slot. This one fails on master with `Expected: True But was: False`.
- `AccessionNumberHasNoValueWhenItIsMissing`: a symbol with no accession number is still `HasValue == false`, so the fix doesn't just make it always true.

Full `QuantConnect.Tests` in Release on .NET 10: 38090 passed, 54 failed, and all 54 fail without my change too. 49 are Python packages missing on my machine, and I re-ran the other 5 on a clean master to check.

#### Note about the 12M gap

I left `TwelveMonths` out because I think it is a data side thing. In #7536, the commit that made these into multi period fields, the generator created `TwelveMonths` for `FileDate`, `FormType`, `PeriodType` and `PeriodEndingDate` but skipped it for both `AccessionNumber` fields, so the period list looks like it comes from the data dictionary. The docs say `AccessionNumber.[Value 1M 2M 3M 6M 9M 12M]`, but that doesn't help, because `EquityPerShareGrowth` is written the same way and really only has 1Y, 3M, 3Y and 5Y.

If you can check that the 12M column exists, I'm happy to add it here. It would be two enum members plus one property and one tuple per class.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

