### PR TITLE
Convert split cash in lieu into the account currency

### DIFF
--- a/Common/Securities/SecurityPortfolioManager.cs
+++ b/Common/Securities/SecurityPortfolioManager.cs
@@ -834,8 +834,10 @@ namespace QuantConnect.Securities
             var quantity = security.Holdings.Quantity / split.SplitFactor;
             var avgPrice = security.Holdings.AveragePrice * split.SplitFactor;
 
-            // we'll model this as a cash adjustment
+            // we'll model this as a cash adjustment. The security is priced in its quote currency,
+            // so the cash in lieu needs to be converted into the account currency
             var leftOver = quantity - (int)quantity;
+            var conversionRate = security.QuoteCurrency.ConversionRate;
 
             security.Holdings.SetHoldings(avgPrice, (int)quantity);
 
@@ -847,13 +849,13 @@ namespace QuantConnect.Securities
                 // will cause this to return null, in this case we can't possibly
                 // have any holdings or price to set since we haven't received
                 // data yet, so just do nothing
-                _baseCurrencyCash.AddAmount(leftOver * split.ReferencePrice * split.SplitFactor);
+                _baseCurrencyCash.AddAmount(leftOver * split.ReferencePrice * split.SplitFactor * conversionRate);
                 return;
             }
 
             security.ApplySplit(split);
             // The data price should have been adjusted already
-            _baseCurrencyCash.AddAmount(leftOver * next.Price);
+            _baseCurrencyCash.AddAmount(leftOver * next.Price * conversionRate);
 
             // security price updated
             InvalidateTotalPortfolioValue();

--- a/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
+++ b/Tests/Common/Securities/SecurityPortfolioManagerTests.cs
@@ -2439,6 +2439,58 @@ namespace QuantConnect.Tests.Common.Securities
             Assert.AreEqual(initialCash + cashDifference, algorithm.Portfolio.CashBook.TotalValueInAccountCurrency);
         }
 
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SplitPartialSharesCashInLieuIsConvertedToAccountCurrency(bool hasData)
+        {
+            var algorithm = new QCAlgorithm();
+            algorithm.SubscriptionManager.SetDataManager(new DataManagerStub(algorithm));
+            algorithm.SetLiveMode(true);
+            // EUR account holding a USD denominated equity
+            algorithm.SetAccountCurrency(Currencies.EUR, 1000m);
+
+            var spy = algorithm.AddEquity("SPY");
+            var usdCash = algorithm.Portfolio.CashBook[Currencies.USD];
+            usdCash.CurrencyConversion = new TestCurrencyConversion(Currencies.USD, Currencies.EUR, 0.9m);
+            Assert.AreEqual(0.9m, spy.QuoteCurrency.ConversionRate);
+
+            if (hasData)
+            {
+                spy.SetMarketPrice(new TradeBar(new DateTime(2000, 01, 01), Symbols.SPY, 10m, 10m, 10m, 10m, 100m, Time.OneMinute));
+            }
+            spy.Holdings.SetHoldings(10m, 3);
+            var initialCash = algorithm.Portfolio.CashBook.TotalValueInAccountCurrency;
+            Assert.AreEqual(1000m, initialCash);
+
+            // 1 for 2 reverse split: 3 shares -> 1 share plus half a share paid in cash.
+            // The reference price is the pre split price
+            var split = new Split(Symbols.SPY, new DateTime(2000, 01, 01), 10m, 2m, SplitType.SplitOccurred);
+            algorithm.Portfolio.ApplySplit(split,
+                spy,
+                algorithm.LiveMode,
+                algorithm.SubscriptionManager.SubscriptionDataConfigService
+                    .GetSubscriptionDataConfigs(spy.Symbol)
+                    .DataNormalizationMode());
+
+            Assert.AreEqual(1, spy.Holdings.Quantity);
+            Assert.AreEqual(20m, spy.Holdings.AveragePrice);
+
+            // half a share at 20 USD post split is 10 USD, which is 9 EUR
+            var expectedCashInLieu = 0.5m * 20m * 0.9m;
+            Assert.AreEqual(9m, expectedCashInLieu);
+            Assert.AreEqual(initialCash + expectedCashInLieu, algorithm.Portfolio.CashBook[Currencies.EUR].Amount);
+            Assert.AreEqual(0m, usdCash.Amount);
+            Assert.AreEqual(initialCash + expectedCashInLieu, algorithm.Portfolio.CashBook.TotalValueInAccountCurrency);
+
+            if (hasData)
+            {
+                // 1 share at 20 USD is 18 EUR, total portfolio value is unchanged by the split
+                Assert.AreEqual(20m, spy.Price);
+                Assert.AreEqual(18m, spy.Holdings.HoldingsValue);
+                Assert.AreEqual(1027m, algorithm.Portfolio.TotalPortfolioValue);
+            }
+        }
+
         [Test]
         public void HoldingsPriceIsUpdatedOnSplit()
         {


### PR DESCRIPTION
#### Description

When `SecurityPortfolioManager.ApplySplit` settles the fractional share remainder of a split in cash, the amount was credited to the account currency cash using the security's quote currency price without any conversion. This inflated the portfolio value whenever the account currency differed from the security's quote currency.

Both the cached-data and the no-data paths are affected. The fix multiplies the cash in lieu by the security's quote currency conversion rate, matching what `ApplyDividend` already does.

Closes #9782

#### Testing

Added `SplitPartialSharesCashInLieuIsConvertedToAccountCurrency` covering the issue scenario (EUR account, USD equity at a 0.9 rate, one-for-two reverse split of three shares) for both the cached-data and no-data branches. The test fails on master with the exact values reported in the issue (EUR 1,010 cash instead of 1,009) and passes with the fix, along with the existing split and dividend tests.

#### Related Issue

#9782

#### Motivation and Context

Portfolio value should not change on a split when exchange rates are unchanged and there are no fees.

#### Requires Documentation Change

No

#### How Has This Been Tested?

`Tests/Common/Securities/SecurityPortfolioManagerTests.cs`, split and dividend tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Add benchmark/profiling results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELsDPabTSwU5kQF7f2ARTE

