### PR TITLE
Expose brokerage data to the algorithm and the live results

### DIFF
--- a/Algorithm/QCAlgorithm.cs
+++ b/Algorithm/QCAlgorithm.cs
@@ -152,6 +152,7 @@ namespace QuantConnect.Algorithm
         private TimeSpan? _warmupTimeSpan;
         private int? _warmupBarCount;
         private Dictionary<string, string> _parameters = new Dictionary<string, string>();
+        private bool _brokerageDataSet;
         private SecurityDefinitionSymbolResolver _securityDefinitionSymbolResolver;
 
         private SecurityDefinitionSymbolResolver SecurityDefinitionSymbolResolver
@@ -749,6 +750,13 @@ namespace QuantConnect.Algorithm
         public ObjectStore ObjectStore { get; private set; }
 
         /// <summary>
+        /// Gets a read-only view of the brokerage data shared by the brokerage, data queue handler or any other component,
+        /// for example account information. Usually empty when not running in live mode
+        /// </summary>
+        [DocumentationAttribute(LiveTrading)]
+        public ReadOnlyExtendedDictionary<string, string> BrokerageData { get; private set; } = new();
+
+        /// <summary>
         /// The current statistics for the running algorithm.
         /// </summary>
         [DocumentationAttribute(StatisticsTag)]
@@ -916,6 +924,25 @@ namespace QuantConnect.Algorithm
         public ReadOnlyExtendedDictionary<string, string> GetParameters()
         {
             return _parameters.ToReadOnlyExtendedDictionary();
+        }
+
+        /// <summary>
+        /// Sets the brokerage data read-only view. Can only be set once, it's shared by the engine
+        /// </summary>
+        /// <param name="brokerageData">The brokerage data</param>
+        [DocumentationAttribute(LiveTrading)]
+        public void SetBrokerageData(ReadOnlyExtendedDictionary<string, string> brokerageData)
+        {
+            if (brokerageData == null)
+            {
+                throw new ArgumentNullException(nameof(brokerageData));
+            }
+            if (_brokerageDataSet && !ReferenceEquals(BrokerageData, brokerageData))
+            {
+                throw new InvalidOperationException("QCAlgorithm.SetBrokerageData(): the brokerage data has already been set, it can only be set once");
+            }
+            BrokerageData = brokerageData;
+            _brokerageDataSet = true;
         }
 
         /// <summary>

--- a/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
+++ b/AlgorithmFactory/Python/Wrappers/AlgorithmPythonWrapper.cs
@@ -427,6 +427,12 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         public ObjectStore ObjectStore => _baseAlgorithm.ObjectStore;
 
         /// <summary>
+        /// Gets a read-only view of the brokerage data shared by the brokerage, data queue handler or any other component,
+        /// for example account information. Usually empty when not running in live mode
+        /// </summary>
+        public ReadOnlyExtendedDictionary<string, string> BrokerageData => _baseAlgorithm.BrokerageData;
+
+        /// <summary>
         /// Returns the current Slice object
         /// </summary>
         public Slice CurrentSlice => _baseAlgorithm.CurrentSlice;
@@ -1163,6 +1169,12 @@ namespace QuantConnect.AlgorithmFactory.Python.Wrappers
         /// </summary>
         /// <param name="parameters">Dictionary containing the parameter names to values</param>
         public void SetParameters(Dictionary<string, string> parameters) => _baseAlgorithm.SetParameters(parameters);
+
+        /// <summary>
+        /// Sets the brokerage data read-only view
+        /// </summary>
+        /// <param name="brokerageData">The brokerage data</param>
+        public void SetBrokerageData(ReadOnlyExtendedDictionary<string, string> brokerageData) => _baseAlgorithm.SetBrokerageData(brokerageData);
 
         /// <summary>
         /// Tries to convert a PyObject into a C# object

--- a/Common/AlgorithmConfiguration.cs
+++ b/Common/AlgorithmConfiguration.cs
@@ -63,6 +63,12 @@ namespace QuantConnect
         public IReadOnlyDictionary<string, string> Parameters { get; set; }
 
         /// <summary>
+        /// The brokerage data used by the live algorithm, if any
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public IReadOnlyDictionary<string, string> BrokerageData { get; set; }
+
+        /// <summary>
         /// Backtest maximum end date
         /// </summary>
         [JsonConverter(typeof(DateTimeJsonConverter), DateFormat.ISOShort, DateFormat.UI)]
@@ -95,9 +101,11 @@ namespace QuantConnect
         /// </summary>
         public AlgorithmConfiguration(string name, ISet<string> tags, string accountCurrency, BrokerageName brokerageName,
             AccountType accountType, IReadOnlyDictionary<string, string> parameters, DateTime startDate, DateTime endDate,
-            DateTime? outOfSampleMaxEndDate, int outOfSampleDays = 0, int tradingDaysPerYear = 0)
+            DateTime? outOfSampleMaxEndDate, int outOfSampleDays = 0, int tradingDaysPerYear = 0,
+            IReadOnlyDictionary<string, string> brokerageData = null)
         {
             Name = name;
+            BrokerageData = brokerageData;
             Tags = tags;
             OutOfSampleMaxEndDate = outOfSampleMaxEndDate;
             TradingDaysPerYear = tradingDaysPerYear;
@@ -139,7 +147,9 @@ namespace QuantConnect
                 backtestNodePacket?.OutOfSampleMaxEndDate,
                 backtestNodePacket?.OutOfSampleDays ?? 0,
                 // use value = 252 like default for backwards compatibility
-                algorithm?.Settings?.TradingDaysPerYear ?? 252);
+                algorithm?.Settings?.TradingDaysPerYear ?? 252,
+                // only included when set, live mode. We take a snapshot since the algorithm's instance can be updated later on
+                algorithm.BrokerageData?.Count > 0 ? new Dictionary<string, string>(algorithm.BrokerageData) : null);
         }
     }
 }

--- a/Common/Interfaces/IAlgorithm.cs
+++ b/Common/Interfaces/IAlgorithm.cs
@@ -407,6 +407,12 @@ namespace QuantConnect.Interfaces
         ObjectStore ObjectStore { get; }
 
         /// <summary>
+        /// Gets a read-only view of the brokerage data shared by the brokerage, data queue handler or any other component,
+        /// for example account information. Usually empty when not running in live mode
+        /// </summary>
+        ReadOnlyExtendedDictionary<string, string> BrokerageData { get; }
+
+        /// <summary>
         /// Returns the current Slice object
         /// </summary>
         Slice CurrentSlice { get; }
@@ -473,6 +479,12 @@ namespace QuantConnect.Interfaces
         /// </summary>
         /// <param name="parameters">Dictionary containing the parameter names to values</param>
         void SetParameters(Dictionary<string, string> parameters);
+
+        /// <summary>
+        /// Sets the brokerage data read-only view
+        /// </summary>
+        /// <param name="brokerageData">The brokerage data</param>
+        void SetBrokerageData(ReadOnlyExtendedDictionary<string, string> brokerageData);
 
         /// <summary>
         /// Determines if the Symbol is shortable at the brokerage

--- a/Common/Util/BaseExtendedDictionary.cs
+++ b/Common/Util/BaseExtendedDictionary.cs
@@ -249,6 +249,15 @@ namespace Common.Util
         }
 
         /// <summary>
+        /// Initializes a new instance of the BaseExtendedDictionary class using the specified dictionary
+        /// </summary>
+        /// <param name="dictionary">The dictionary to use as the data source</param>
+        /// <param name="copy">True to copy the elements into a new dictionary, false to wrap the given instance so that any changes made to it are reflected</param>
+        public BaseExtendedDictionary(Dictionary<TKey, TValue> dictionary, bool copy) : base(copy ? new Dictionary<TKey, TValue>(dictionary) : dictionary)
+        {
+        }
+
+        /// <summary>
         /// Initializes a new instance of the BaseExtendedDictionary class
         /// using the specified <paramref name="data"/> as a data source
         /// </summary>

--- a/Common/Util/ReadOnlyExtendedDictionary.cs
+++ b/Common/Util/ReadOnlyExtendedDictionary.cs
@@ -41,6 +41,15 @@ namespace Common.Util
         }
 
         /// <summary>
+        /// Initializes a new instance of the ReadOnlyExtendedDictionary class using the specified dictionary
+        /// </summary>
+        /// <param name="dictionary">The dictionary to use as the data source</param>
+        /// <param name="copy">True to copy the elements into a new dictionary, false to wrap the given instance so that any changes made to it are reflected</param>
+        public ReadOnlyExtendedDictionary(Dictionary<TKey, TValue> dictionary, bool copy) : base(dictionary, copy)
+        {
+        }
+
+        /// <summary>
         /// Initializes a new instance of the ReadOnlyExtendedDictionary class
         /// using the specified <paramref name="data"/> as a data source
         /// </summary>
@@ -99,7 +108,7 @@ namespace Common.Util
         /// </summary>
         /// <param name="key">The key of the element to add</param>
         /// <param name="value">The value of the element to add</param>
-        public new void Add(TKey key, TValue value)
+        public override void Add(TKey key, TValue value)
         {
             throw new InvalidOperationException("Dictionary is read-only");
         }
@@ -108,7 +117,7 @@ namespace Common.Util
         /// Adds an element with the provided key-value pair to the dictionary
         /// </summary>
         /// <param name="item">The key-value pair to add</param>
-        public new void Add(KeyValuePair<TKey, TValue> item)
+        public override void Add(KeyValuePair<TKey, TValue> item)
         {
             throw new InvalidOperationException("Dictionary is read-only");
         }
@@ -118,7 +127,7 @@ namespace Common.Util
         /// </summary>
         /// <param name="item">The key-value pair to remove</param>
         /// <returns>true if the key-value pair was successfully removed; otherwise, false</returns>
-        public new bool Remove(KeyValuePair<TKey, TValue> item)
+        public override bool Remove(KeyValuePair<TKey, TValue> item)
         {
             throw new InvalidOperationException("Dictionary is read-only");
         }

--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -126,6 +126,9 @@ namespace QuantConnect.Lean.Engine
 
                     algorithm.ProjectId = job.ProjectId;
 
+                    // share the brokerage data with the algorithm right away so it's available during initialization
+                    algorithm.SetBrokerageData(AlgorithmHandlers.Results.BrokerageData);
+
                     // Set algorithm in ILeanManager
                     SystemHandlers.LeanManager.SetAlgorithm(algorithm);
 

--- a/Engine/Results/BacktestingResultHandler.cs
+++ b/Engine/Results/BacktestingResultHandler.cs
@@ -401,7 +401,7 @@ namespace QuantConnect.Lean.Engine.Results
                     result = new BacktestResultPacket(_job,
                         new BacktestResult(new BacktestResultParameters(charts, orders, profitLoss, statisticsResults.Summary, runtime,
                             statisticsResults.RollingPerformances, orderEvents, statisticsResults.TotalPerformance,
-                            AlgorithmConfiguration.Create(Algorithm, _job), GetAlgorithmState(endTime))),
+                            CreateAlgorithmConfiguration(_job), GetAlgorithmState(endTime))),
                         Algorithm.EndDate, Algorithm.StartDate);
                 }
                 else

--- a/Engine/Results/BaseResultsHandler.cs
+++ b/Engine/Results/BaseResultsHandler.cs
@@ -29,6 +29,7 @@ using QuantConnect.Packets;
 using QuantConnect.Securities.Positions;
 using QuantConnect.Statistics;
 using QuantConnect.Util;
+using Common.Util;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -249,6 +250,16 @@ namespace QuantConnect.Lean.Engine.Results
         protected Dictionary<string, string> State { get; set; }
 
         /// <summary>
+        /// Brokerage data shared with the user and the algorithm, see <see cref="AddBrokerageData"/>
+        /// </summary>
+        private readonly Dictionary<string, string> _brokerageData = new();
+
+        /// <summary>
+        /// Read only view of the brokerage data, see <see cref="AddBrokerageData"/>. Shared with the algorithm
+        /// </summary>
+        public ReadOnlyExtendedDictionary<string, string> BrokerageData { get; }
+
+        /// <summary>
         /// The handler responsible for communicating messages to listeners
         /// </summary>
         protected IMessagingHandler MessagingHandler { get; set; }
@@ -326,6 +337,8 @@ namespace QuantConnect.Lean.Engine.Results
 
             Messages = new ConcurrentQueue<Packet>();
             RuntimeStatistics = new Dictionary<string, string>();
+            // same instance, so any entries added later are visible through the view
+            BrokerageData = new ReadOnlyExtendedDictionary<string, string>(_brokerageData, copy: false);
             StartTime = DateTime.UtcNow;
             CompileId = "";
             AlgorithmId = "";
@@ -541,6 +554,38 @@ namespace QuantConnect.Lean.Engine.Results
             // Wire algorithm name and tags updates
             algorithm.NameUpdated += (sender, name) => AlgorithmNameUpdated(name);
             algorithm.TagsUpdated += (sender, tags) => AlgorithmTagsUpdated(tags);
+        }
+
+        /// <summary>
+        /// Adds or updates a brokerage data entry. Key value pairs the brokerage, data queue handler or any other component
+        /// wants to share with the user, through the results, and the algorithm, for example account information.
+        /// Sensitive data, like credentials, should never be added
+        /// </summary>
+        /// <param name="key">The brokerage data key</param>
+        /// <param name="value">The brokerage data value</param>
+        public virtual void AddBrokerageData(string key, string value)
+        {
+            if (string.IsNullOrEmpty(key))
+            {
+                return;
+            }
+            lock (_brokerageData)
+            {
+                _brokerageData[key] = value ?? string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Creates the algorithm configuration to include in the results, taking a snapshot of the current brokerage data
+        /// </summary>
+        /// <param name="backtestNodePacket">The associated backtest node packet if any</param>
+        /// <returns>A new <see cref="AlgorithmConfiguration"/> instance</returns>
+        protected AlgorithmConfiguration CreateAlgorithmConfiguration(BacktestNodePacket backtestNodePacket = null)
+        {
+            lock (_brokerageData)
+            {
+                return AlgorithmConfiguration.Create(Algorithm, backtestNodePacket);
+            }
         }
 
         /// <summary>

--- a/Engine/Results/IResultHandler.cs
+++ b/Engine/Results/IResultHandler.cs
@@ -23,6 +23,7 @@ using QuantConnect.Data.UniverseSelection;
 using QuantConnect.Interfaces;
 using QuantConnect.Orders;
 using QuantConnect.Packets;
+using Common.Util;
 using QuantConnect.Statistics;
 
 namespace QuantConnect.Lean.Engine.Results
@@ -140,6 +141,20 @@ namespace QuantConnect.Lean.Engine.Results
         /// <param name="key">Runtime headline statistic name</param>
         /// <param name="value">Runtime headline statistic value</param>
         void RuntimeStatistic(string key, string value);
+
+        /// <summary>
+        /// Adds or updates a brokerage data entry. Key value pairs the brokerage, data queue handler or any other component
+        /// wants to share with the user, through the results, and the algorithm, for example account information.
+        /// Sensitive data, like credentials, should never be added
+        /// </summary>
+        /// <param name="key">The brokerage data key</param>
+        /// <param name="value">The brokerage data value</param>
+        void AddBrokerageData(string key, string value);
+
+        /// <summary>
+        /// Read only view of the brokerage data, see <see cref="AddBrokerageData"/>. Shared with the algorithm
+        /// </summary>
+        ReadOnlyExtendedDictionary<string, string> BrokerageData { get; }
 
         /// <summary>
         /// Send a new order event.

--- a/Engine/Results/LiveTradingResultHandler.cs
+++ b/Engine/Results/LiveTradingResultHandler.cs
@@ -263,7 +263,8 @@ namespace QuantConnect.Lean.Engine.Results
                         var orders = new Dictionary<int, Order>(TransactionHandler.Orders);
                         var complete = new LiveResultPacket(_job, new LiveResult(new LiveResultParameters(chartComplete, orders,
                             Algorithm.Transactions.TransactionRecord, holdings, Algorithm.Portfolio.CashBook, deltaStatistics,
-                            runtimeStatistics, orderEvents, statistics.TotalPerformance, serverStatistics, state: GetAlgorithmState())));
+                            runtimeStatistics, orderEvents, statistics.TotalPerformance, serverStatistics,
+                            algorithmConfiguration: CreateAlgorithmConfiguration(), state: GetAlgorithmState())));
                         StoreResult(complete);
                         _holdingsChangeMonitor.MarkStored();
                         _nextChartsUpdate = DateTime.UtcNow.Add(ChartUpdateInterval);
@@ -523,6 +524,8 @@ namespace QuantConnect.Lean.Engine.Results
                     runtimeStatistics: runtimeStatistics,
                     orderEvents: null, // we stored order events separately
                     serverStatistics: serverStatistics,
+                    // stored from the start so it's available to the user while the algorithm is running
+                    algorithmConfiguration: Algorithm != null ? CreateAlgorithmConfiguration() : null,
                     state: algorithmState));
 
                 SaveResults($"{AlgorithmId}.json", result);
@@ -851,7 +854,7 @@ namespace QuantConnect.Lean.Engine.Results
                     result = new LiveResultPacket(_job,
                         new LiveResult(new LiveResultParameters(charts, orders, profitLoss, new Dictionary<string, Holding>(),
                             Algorithm.Portfolio.CashBook, statisticsResults.Summary, runtime, GetOrderEventsToStore(), serverStatistics: serverStatistics,
-                            algorithmConfiguration: AlgorithmConfiguration.Create(Algorithm, null), state: endState, totalPerformance: statisticsResults.TotalPerformance)));
+                            algorithmConfiguration: CreateAlgorithmConfiguration(), state: endState, totalPerformance: statisticsResults.TotalPerformance)));
                 }
                 else
                 {

--- a/Tests/Common/AlgorithmConfigurationTests.cs
+++ b/Tests/Common/AlgorithmConfigurationTests.cs
@@ -22,6 +22,7 @@ using Newtonsoft.Json;
 using QuantConnect.Packets;
 using QuantConnect.Algorithm;
 using QuantConnect.Brokerages;
+using Common.Util;
 using Newtonsoft.Json.Serialization;
 
 namespace QuantConnect.Tests.Common
@@ -105,6 +106,40 @@ namespace QuantConnect.Tests.Common
             Assert.AreEqual(algorithmConfiguration.OutOfSampleMaxEndDate, deserialize.OutOfSampleMaxEndDate);
             Assert.AreEqual(algorithmConfiguration.StartDate, deserialize.StartDate);
             Assert.AreEqual(algorithmConfiguration.Tags, deserialize.Tags);
+        }
+
+        [Test]
+        public void BrokerageDataIsOnlyIncludedWhenSet()
+        {
+            var algorithm = new QCAlgorithm();
+
+            // not set, e.g. backtesting
+            var algorithmConfiguration = AlgorithmConfiguration.Create(algorithm, null);
+            Assert.IsNull(algorithmConfiguration.BrokerageData);
+            var serialized = JsonConvert.SerializeObject(algorithmConfiguration);
+            Assert.IsFalse(serialized.Contains("BrokerageData", StringComparison.InvariantCultureIgnoreCase));
+
+            // set, e.g. live trading
+            var brokerageData = new Dictionary<string, string> { { "some-key", "some value" }, { "some-other-key", "another value" } };
+            algorithm.SetBrokerageData(new ReadOnlyExtendedDictionary<string, string>(brokerageData, copy: false));
+            algorithmConfiguration = AlgorithmConfiguration.Create(algorithm, null);
+            CollectionAssert.AreEquivalent(brokerageData, algorithmConfiguration.BrokerageData);
+
+            // the configuration holds a snapshot, later changes are reflected by the algorithm but not by the existing configuration
+            brokerageData.Remove("some-other-key");
+            brokerageData["some-key"] = "";
+            Assert.AreEqual(2, algorithmConfiguration.BrokerageData.Count);
+            Assert.AreEqual("some value", algorithmConfiguration.BrokerageData["some-key"]);
+            CollectionAssert.AreEquivalent(brokerageData, algorithm.BrokerageData);
+
+            algorithmConfiguration = AlgorithmConfiguration.Create(algorithm, null);
+            CollectionAssert.AreEquivalent(brokerageData, algorithmConfiguration.BrokerageData);
+
+            serialized = JsonConvert.SerializeObject(algorithmConfiguration);
+            Assert.IsTrue(serialized.Contains("\"BrokerageData\":{\"some-key\":\"\"}", StringComparison.InvariantCulture));
+
+            var deserialized = JsonConvert.DeserializeObject<AlgorithmConfiguration>(serialized);
+            CollectionAssert.AreEquivalent(brokerageData, deserialized.BrokerageData);
         }
 
         private static TestCaseData[] AlgorithmConfigurationTestCases => new[]

--- a/Tests/Common/BaseExtendedDictionaryTests.cs
+++ b/Tests/Common/BaseExtendedDictionaryTests.cs
@@ -240,6 +240,45 @@ namespace QuantConnect.Tests.Common
         }
 
         [Test]
+        public void ReadOnlyExtendedDictionaryIsReadOnlyThroughInterfaces()
+        {
+            var source = new Dictionary<string, int> { { "test", 1 } };
+            var dict = new ReadOnlyExtendedDictionary<string, int>(source, copy: false);
+            var dictionary = (IDictionary<string, int>)dict;
+            var collection = (ICollection<KeyValuePair<string, int>>)dict;
+
+            Assert.Throws<InvalidOperationException>(() => dictionary.Add("newkey", 123));
+            Assert.Throws<InvalidOperationException>(() => dictionary["test"] = 2);
+            Assert.Throws<InvalidOperationException>(() => dictionary.Remove("test"));
+            Assert.Throws<InvalidOperationException>(() => dictionary.Clear());
+            Assert.Throws<InvalidOperationException>(() => collection.Add(new KeyValuePair<string, int>("newkey", 123)));
+            Assert.Throws<InvalidOperationException>(() => collection.Remove(new KeyValuePair<string, int>("test", 1)));
+
+            Assert.AreEqual(1, source.Count);
+            Assert.AreEqual(1, source["test"]);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void ReadOnlyExtendedDictionaryCopiesOrWrapsSource(bool copy)
+        {
+            var source = new Dictionary<string, int> { { "test", 1 } };
+            var dict = new ReadOnlyExtendedDictionary<string, int>(source, copy);
+            Assert.AreEqual(1, dict["test"]);
+
+            // changes made to the source are only reflected when wrapping it
+            source["test"] = 2;
+            source["other"] = 3;
+            Assert.AreEqual(copy ? 1 : 2, dict["test"]);
+            Assert.AreEqual(!copy, dict.ContainsKey("other"));
+
+            // still read only either way
+            Assert.Throws<InvalidOperationException>(() => dict["test"] = 5);
+            Assert.Throws<InvalidOperationException>(() => dict.Add("newkey", 123));
+            Assert.AreEqual(2, source["test"]);
+        }
+
+        [Test]
         public void BaseExtendedDictionaryBehavesAsPythonDictionary()
         {
             using var _ = Py.GIL();

--- a/Tests/Engine/AlgorithmManagerTests.cs
+++ b/Tests/Engine/AlgorithmManagerTests.cs
@@ -40,6 +40,7 @@ using QuantConnect.Scheduling;
 using QuantConnect.Securities;
 using QuantConnect.Statistics;
 using QuantConnect.Util;
+using Common.Util;
 using Log = QuantConnect.Logging.Log;
 
 namespace QuantConnect.Tests.Engine
@@ -234,6 +235,12 @@ namespace QuantConnect.Tests.Engine
             public void SendStatusUpdate(AlgorithmStatus status, string message = "")
             {
             }
+
+            public void AddBrokerageData(string key, string value)
+            {
+            }
+
+            public ReadOnlyExtendedDictionary<string, string> BrokerageData { get; } = new();
 
             public void RuntimeStatistic(string key, string value)
             {

--- a/Tests/Engine/Results/LiveTradingResultHandlerTests.cs
+++ b/Tests/Engine/Results/LiveTradingResultHandlerTests.cs
@@ -36,6 +36,7 @@ using QuantConnect.Lean.Engine.TransactionHandlers;
 using QuantConnect.Tests.Common.Data.UniverseSelection;
 using QuantConnect.Data.Custom.IconicTypes;
 using System.Collections.Generic;
+using Common.Util;
 
 namespace QuantConnect.Tests.Engine.Results
 {
@@ -500,9 +501,119 @@ namespace QuantConnect.Tests.Engine.Results
             }
         }
 
+        [Test]
+        public void StoredResultsCarryAlgorithmConfigurationFromTheStart()
+        {
+            using var api = new Api.Api();
+            using var messaging = new QuantConnect.Messaging.Messaging();
+            var deployId = "TestDeployId";
+            var job = new LiveNodePacket { DeployId = deployId };
+            var resultHandler = new TestableStoredResultsHandler();
+
+            try
+            {
+                var algorithm = new AlgorithmStub();
+                algorithm.SetDateTime(DateTime.UtcNow);
+                // normally initialized by the setup handlers, required for statistics generation
+                algorithm.Settings.TradingDaysPerYear = 365;
+                algorithm.SetParameters(new Dictionary<string, string> { { "ema-fast", "10" } });
+                algorithm.PostInitialize();
+
+                var transactionHandler = new BacktestingTransactionHandler();
+                using var brokerage = new BacktestingBrokerage(algorithm);
+                transactionHandler.Initialize(algorithm, brokerage, resultHandler);
+                algorithm.Transactions.SetOrderProcessor(transactionHandler);
+
+                resultHandler.Initialize(new(job, messaging, api, transactionHandler, null));
+                // the engine shares the view right after creating the algorithm
+                algorithm.SetBrokerageData(resultHandler.BrokerageData);
+                // e.g. the brokerage or data queue handler, which are created before the algorithm is set
+                resultHandler.AddBrokerageData("some-key", "some value");
+                resultHandler.SetAlgorithm(algorithm, 100000);
+                algorithm.SetLocked();
+
+                var expectedBrokerageData = new Dictionary<string, string> { { "some-key", "some value" } };
+                CollectionAssert.AreEquivalent(expectedBrokerageData, algorithm.BrokerageData);
+
+                // the first update pass stores the status file and the complete results right away, no final result required
+                var expected = new[] { $"{deployId}.json", $"{deployId}-{DateTime.UtcNow:yyyy-MM-dd}_minute.json" };
+                Assert.IsTrue(resultHandler.WaitForStoredResults(expected, TimeSpan.FromSeconds(30)), "Initial store did not happen");
+
+                foreach (var name in expected)
+                {
+                    foreach (var result in resultHandler.GetStoredResults(name))
+                    {
+                        Assert.IsNotNull(result.AlgorithmConfiguration, $"'{name}' is missing the algorithm configuration");
+                        CollectionAssert.AreEquivalent(expectedBrokerageData, result.AlgorithmConfiguration.BrokerageData);
+                        Assert.AreEqual("10", result.AlgorithmConfiguration.Parameters["ema-fast"]);
+                    }
+                }
+            }
+            finally
+            {
+                resultHandler.Exit();
+            }
+        }
+
+        [Test]
+        public void BrokerageDataIsSharedWithTheAlgorithmAndTheResults()
+        {
+            using var api = new Api.Api();
+            using var messaging = new QuantConnect.Messaging.Messaging();
+            var deployId = "TestDeployId";
+            var resultHandler = new TestableStoredResultsHandler();
+            resultHandler.Initialize(new(new LiveNodePacket { DeployId = deployId }, messaging, api, new BacktestingTransactionHandler(), null));
+
+            var algorithm = new AlgorithmStub();
+            algorithm.SetFinishedWarmingUp();
+            Assert.IsEmpty(algorithm.BrokerageData);
+            Assert.IsEmpty(resultHandler.BrokerageData);
+
+            // the engine shares the view right after creating the algorithm, so it's available during initialization
+            algorithm.SetBrokerageData(resultHandler.BrokerageData);
+            resultHandler.AddBrokerageData("account", "123");
+            Assert.AreEqual("123", algorithm.BrokerageData["account"]);
+            Assert.AreEqual("123", resultHandler.BrokerageData["account"]);
+
+            resultHandler.SetAlgorithm(algorithm, 100000);
+            Assert.AreSame(resultHandler.BrokerageData, algorithm.BrokerageData);
+
+            // it's only set once by the engine: the same instance is fine, a different one is not
+            Assert.DoesNotThrow(() => algorithm.SetBrokerageData(resultHandler.BrokerageData));
+            Assert.Throws<InvalidOperationException>(() => algorithm.SetBrokerageData(new ReadOnlyExtendedDictionary<string, string>()));
+            Assert.AreSame(resultHandler.BrokerageData, algorithm.BrokerageData);
+
+            resultHandler.AddBrokerageData("environment", "paper");
+            Assert.AreEqual("paper", algorithm.BrokerageData["environment"]);
+
+            // entries are updated in place, empty keys are ignored and null values are stored as empty
+            resultHandler.AddBrokerageData("account", "456");
+            resultHandler.AddBrokerageData("", "ignored");
+            resultHandler.AddBrokerageData(null, "ignored");
+            resultHandler.AddBrokerageData("empty", null);
+            CollectionAssert.AreEquivalent(new Dictionary<string, string> { { "account", "456" }, { "environment", "paper" }, { "empty", "" } }, algorithm.BrokerageData);
+
+            // read only for the algorithm
+            Assert.Throws<InvalidOperationException>(() => algorithm.BrokerageData.Add("new-key", "new value"));
+            Assert.Throws<InvalidOperationException>(() => algorithm.BrokerageData.Remove("account"));
+            Assert.Throws<InvalidOperationException>(() => algorithm.BrokerageData["account"] = "new value");
+
+            // the final result is stored on exit
+            resultHandler.Exit();
+            var stored = resultHandler.GetStoredResults($"{deployId}.json");
+            Assert.IsNotEmpty(stored);
+            foreach (var result in stored)
+            {
+                CollectionAssert.AreEquivalent(algorithm.BrokerageData, result.AlgorithmConfiguration.BrokerageData);
+            }
+        }
+
         private class TestableStoredResultsHandler : LiveTradingResultHandler
         {
             public List<KeyValuePair<string, Result>> StoredResults { get; } = new();
+
+            // speed up the update loop
+            protected override TimeSpan MainUpdateInterval => TimeSpan.FromMilliseconds(100);
 
             public override void SaveResults(string name, Result result)
             {
@@ -510,6 +621,28 @@ namespace QuantConnect.Tests.Engine.Results
                 {
                     StoredResults.Add(new(name, result));
                 }
+            }
+
+            public List<Result> GetStoredResults(string name)
+            {
+                lock (StoredResults)
+                {
+                    return StoredResults.Where(pair => pair.Key.EndsWith(name, StringComparison.InvariantCulture)).Select(pair => pair.Value).ToList();
+                }
+            }
+
+            public bool WaitForStoredResults(IEnumerable<string> names, TimeSpan timeout)
+            {
+                var start = DateTime.UtcNow;
+                while (DateTime.UtcNow - start < timeout)
+                {
+                    if (names.All(name => GetStoredResults(name).Count > 0))
+                    {
+                        return true;
+                    }
+                    Thread.Sleep(50);
+                }
+                return names.All(name => GetStoredResults(name).Count > 0);
             }
 
             public override string SaveLogs(string id, List<LogEntry> logs)


### PR DESCRIPTION
#### Description
- Adds `IResultHandler.AddBrokerageData(key, value)`, backed by a dictionary owned by the result handler. Any component (brokerage, data queue handler or other) opts in by adding what it considers safe to share, for example account information. Nothing is exposed by default and the job packet `BrokerageData` (credentials) is never exposed.
- The result handler exposes a `ReadOnlyExtendedDictionary` view over it, which the engine hands to the algorithm right after creating it, available as `QCAlgorithm.BrokerageData` (`self.brokerage_data`) from `Initialize` on. It can only be set once.
- Adds `AlgorithmConfiguration.BrokerageData`, only serialized when set, snapshot under lock. Stored in the live results from the first update (status file and complete results), not only on the final result, so it can be displayed while the algorithm is running.
- Adds a non copying constructor to `BaseExtendedDictionary`/`ReadOnlyExtendedDictionary` so a live read only view can be shared.
- Fixes `ReadOnlyExtendedDictionary` hiding (`new`) instead of overriding the mutating members `Add`/`Remove(KeyValuePair)`, which let `IDictionary`/`ICollection` references mutate a read only dictionary.

#### Related Issue
N/A

#### Motivation and Context
Allow brokerages and data queue handlers to share non sensitive data with the user, through the live results, and with the algorithm.

#### Requires Documentation Change
`QCAlgorithm.BrokerageData` / `self.brokerage_data`

#### How Has This Been Tested?
New and updated unit tests: `AlgorithmConfigurationTests`, `LiveTradingResultHandlerTests`, `BaseExtendedDictionaryTests`. Existing result handler, report, python and util suites.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
